### PR TITLE
Chore/queue modifications

### DIFF
--- a/internal/api/queue/queue_listener.go
+++ b/internal/api/queue/queue_listener.go
@@ -165,7 +165,7 @@ func (ql *QueueListenerImpl) processMessage(msg amqp.Delivery) {
 		}
 		return
 	}
-	
+
 	switch queueMessage.Type {
 	case MessageTypeTask:
 		submissionId, err := ql.queueService.GetSubmissionId(tx, queueMessage.MessageId)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -175,8 +175,8 @@ func NewConfig() *Config {
 			User:              queueUser,
 			Password:          queuePassword,
 		},
-		FileStorageUrl:   fileStorageUrl,
-		Dump:             dump,
+		FileStorageUrl: fileStorageUrl,
+		Dump:           dump,
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,12 +2,8 @@ package config
 
 import (
 	"os"
-	"slices"
 	"strconv"
-	"strings"
 
-	"github.com/mini-maxit/backend/package/domain/models"
-	"github.com/mini-maxit/backend/package/domain/schemas"
 	"github.com/mini-maxit/backend/package/utils"
 	"go.uber.org/zap"
 )
@@ -18,8 +14,6 @@ type Config struct {
 	Api            ApiConfig
 	BrokerConfig   BrokerConfig
 	Dump           bool
-
-	EnabledLanguages []schemas.LanguageConfig
 }
 
 type DBConfig struct {
@@ -54,89 +48,6 @@ const (
 	defaultQueueName         = "worker_queue"
 	defaultResponseQueueName = "worker_response_queue"
 )
-
-// DefaultLanguages is a list of languages that is enabled by default
-var DefaultLanguages = []schemas.LanguageConfig{
-	{
-		Type:          models.LangTypeC,
-		Version:       "99",
-		FileExtension: "c",
-	},
-	{
-		Type:          models.LangTypeC,
-		Version:       "11",
-		FileExtension: "c",
-	},
-	{
-		Type:          models.LangTypeC,
-		Version:       "18",
-		FileExtension: "c",
-	},
-	{
-		Type:          models.LangTypeCPP,
-		Version:       "11",
-		FileExtension: "cpp",
-	},
-	{
-		Type:          models.LangTypeCPP,
-		Version:       "14",
-		FileExtension: "cpp",
-	},
-	{
-		Type:          models.LangTypeCPP,
-		Version:       "17",
-		FileExtension: "cpp",
-	},
-	{
-		Type:          models.LangTypeCPP,
-		Version:       "20",
-		FileExtension: "cpp",
-	},
-}
-
-// AvailableLanguages is a list of languages that is acrively supported by the system and can be used if enabled.
-var AvailableLanguages = []schemas.LanguageConfig{
-	{
-		Type:          models.LangTypeC,
-		Version:       "99",
-		FileExtension: "c",
-	},
-	{
-		Type:          models.LangTypeC,
-		Version:       "11",
-		FileExtension: "c",
-	},
-	{
-		Type:          models.LangTypeC,
-		Version:       "18",
-		FileExtension: "c",
-	},
-	{
-		Type:          models.LangTypeCPP,
-		Version:       "11",
-		FileExtension: "cpp",
-	},
-	{
-		Type:          models.LangTypeCPP,
-		Version:       "14",
-		FileExtension: "cpp",
-	},
-	{
-		Type:          models.LangTypeCPP,
-		Version:       "17",
-		FileExtension: "cpp",
-	},
-	{
-		Type:          models.LangTypeCPP,
-		Version:       "20",
-		FileExtension: "cpp",
-	},
-	{
-		Type:          models.LangTypeCPP,
-		Version:       "23",
-		FileExtension: "cpp",
-	},
-}
 
 // NewConfig creates new Config instance
 //
@@ -266,7 +177,6 @@ func NewConfig() *Config {
 		},
 		FileStorageUrl:   fileStorageUrl,
 		Dump:             dump,
-		EnabledLanguages: parseLanguages(os.Getenv("LANGUAGES"), log),
 	}
 }
 
@@ -276,26 +186,4 @@ func validatePort(port string, which string, log *zap.SugaredLogger) uint16 {
 		log.Panicf("invalid %s port number %s", which, port)
 	}
 	return uint16(p)
-}
-
-func parseLanguages(input string, log *zap.SugaredLogger) []schemas.LanguageConfig {
-	if input == "" {
-		log.Warn("LANGUAGES is not set. Using default languages")
-		return DefaultLanguages
-	}
-	langs := make([]schemas.LanguageConfig, 0)
-	languages := strings.Split(input, ",")
-	for _, lang := range languages {
-		parts := strings.Split(lang, ":")
-		if len(parts) != 2 {
-			log.Panicf("invalid language format in config: %s. For available options refer to documentation", lang)
-		}
-		language := schemas.LanguageConfig{Type: models.LanguageType(parts[0]), Version: parts[1]}
-		if !slices.Contains(AvailableLanguages, language) {
-			log.Panicf("language %s is not available. Available languages: %v, for more refer to documentation", lang, AvailableLanguages)
-		}
-		langs = append(langs, language)
-	}
-
-	return langs
 }

--- a/internal/initialization/initialization.go
+++ b/internal/initialization/initialization.go
@@ -153,7 +153,7 @@ func NewInitialization(cfg *config.Config) *Initialization {
 	userRoute := routes.NewUserRoute(userService)
 
 	// Queue listener
-	queueListener, err := queue.NewQueueListener(conn, channel, db, taskService, queueService, submissionService, langService,cfg.BrokerConfig.ResponseQueueName)
+	queueListener, err := queue.NewQueueListener(conn, channel, db, taskService, queueService, submissionService, langService, cfg.BrokerConfig.ResponseQueueName)
 	if err != nil {
 		log.Panicf("Failed to create queue listener: %s", err.Error())
 	}

--- a/internal/initialization/initialization.go
+++ b/internal/initialization/initialization.go
@@ -134,24 +134,15 @@ func NewInitialization(cfg *config.Config) *Initialization {
 	if err != nil {
 		log.Panicf("Failed to create queue service: %s", err.Error())
 	}
+	err = queueService.PublishHandshake()
+	if err != nil {
+		log.Panicf("Failed to publish handshake: %s", err.Error())
+	}
 	sessionService := service.NewSessionService(sessionRepository, userRepository)
 	authService := service.NewAuthService(userRepository, sessionService)
 	groupService := service.NewGroupService(groupRepository, userRepository, userService)
 	langService := service.NewLanguageService(langRepository)
 	submissionService := service.NewSubmissionService(submissionRepository, submissionResultRepository, inputOutputRepository, testResultRepository, langService, taskService, userService)
-	tx, err = db.BeginTransaction()
-	if err != nil {
-		log.Panicf("Failed to connect to database to init languages: %s", err.Error())
-	}
-	err = langService.InitLanguages(tx, cfg.EnabledLanguages)
-	if err != nil {
-		log.Panicf("Failed to init languages: %s", err.Error())
-		tx.Rollback()
-	}
-	err = db.Commit()
-	if err != nil {
-		log.Panicf("Failed to commit transaction after lang init: %s", err.Error())
-	}
 
 	// Routes
 	authRoute := routes.NewAuthRoute(userService, authService)
@@ -162,7 +153,7 @@ func NewInitialization(cfg *config.Config) *Initialization {
 	userRoute := routes.NewUserRoute(userService)
 
 	// Queue listener
-	queueListener, err := queue.NewQueueListener(conn, channel, db, taskService, queueService, submissionService, cfg.BrokerConfig.ResponseQueueName)
+	queueListener, err := queue.NewQueueListener(conn, channel, db, taskService, queueService, submissionService, langService,cfg.BrokerConfig.ResponseQueueName)
 	if err != nil {
 		log.Panicf("Failed to create queue listener: %s", err.Error())
 	}

--- a/internal/testutils/mocks.go
+++ b/internal/testutils/mocks.go
@@ -200,7 +200,7 @@ func (tr *MockTaskRepository) GetTaskByTitle(tx *gorm.DB, title string) (*models
 	return nil, gorm.ErrRecordNotFound
 }
 
-func (tr *MockTaskRepository) GetTaskTimeLimits(tx *gorm.DB, taskId int64) ([]float64, error) {
+func (tr *MockTaskRepository) GetTaskTimeLimits(tx *gorm.DB, taskId int64) ([]int64, error) {
 	panic("implement me")
 	// if task, ok := tr.tasks[taskId]; ok {
 	// 	return task.TimeLimits, nil
@@ -208,7 +208,7 @@ func (tr *MockTaskRepository) GetTaskTimeLimits(tx *gorm.DB, taskId int64) ([]fl
 	// return nil, gorm.ErrRecordNotFound
 }
 
-func (tr *MockTaskRepository) GetTaskMemoryLimits(tx *gorm.DB, taskId int64) ([]float64, error) {
+func (tr *MockTaskRepository) GetTaskMemoryLimits(tx *gorm.DB, taskId int64) ([]int64, error) {
 	panic("implement me")
 	// if task, ok := tr.tasks[taskId]; ok {
 	// 	return task.MemoryLimits, nil

--- a/package/domain/models/input_output.go
+++ b/package/domain/models/input_output.go
@@ -2,10 +2,10 @@ package models
 
 // InputOutput is a struct that contains the input and output of the task
 type InputOutput struct {
-	Id          int64   `gorm:"primaryKey"`
-	TaskId      int64   `gorm:"not null"`
-	Order       int     `gorm:"not null"`
+	Id          int64 `gorm:"primaryKey"`
+	TaskId      int64 `gorm:"not null"`
+	Order       int   `gorm:"not null"`
 	TimeLimit   int64 `gorm:"not null"`
 	MemoryLimit int64 `gorm:"not null"`
-	Task        Task    `gorm:"foreignKey:TaskId; references:Id"`
+	Task        Task  `gorm:"foreignKey:TaskId; references:Id"`
 }

--- a/package/domain/models/input_output.go
+++ b/package/domain/models/input_output.go
@@ -5,7 +5,7 @@ type InputOutput struct {
 	Id          int64   `gorm:"primaryKey"`
 	TaskId      int64   `gorm:"not null"`
 	Order       int     `gorm:"not null"`
-	TimeLimit   float64 `gorm:"not null"`
-	MemoryLimit float64 `gorm:"not null"`
+	TimeLimit   int64 `gorm:"not null"`
+	MemoryLimit int64 `gorm:"not null"`
 	Task        Task    `gorm:"foreignKey:TaskId; references:Id"`
 }

--- a/package/domain/models/language_config.go
+++ b/package/domain/models/language_config.go
@@ -2,14 +2,10 @@ package models
 
 type LanguageType string
 
-const (
-	LangTypeC   LanguageType = "c"
-	LangTypeCPP LanguageType = "cpp"
-)
-
 type LanguageConfig struct {
-	Id            int64        `gorm:"primaryKey;"`
-	Type          LanguageType `gorm:"not null;"`
-	Version       string       `gorm:"not null;"`
-	FileExtension string       `gorm:"not null;"`
+	Id            int64  `gorm:"primaryKey;"`
+	Type          string `gorm:"not null;"`
+	Version       string `gorm:"not null;"`
+	FileExtension string `gorm:"not null;"`
+	Disabled      bool   `gorm:"not null;"`
 }

--- a/package/domain/schemas/language_config.go
+++ b/package/domain/schemas/language_config.go
@@ -1,10 +1,8 @@
 package schemas
 
-import "github.com/mini-maxit/backend/package/domain/models"
-
 type LanguageConfig struct {
-	Id            int64               `json:"id"`
-	Type          models.LanguageType `json:"language"`
-	Version       string              `json:"version"`
-	FileExtension string              `json:"file_extension"`
+	Id            int64  `json:"id"`
+	Type          string `json:"language"`
+	Version       string `json:"version"`
+	FileExtension string `json:"file_extension"`
 }

--- a/package/domain/schemas/queue.go
+++ b/package/domain/schemas/queue.go
@@ -1,16 +1,39 @@
 package schemas
 
+import "encoding/json"
+
 type QueueResponseMessage struct {
-	MessageId string      `json:"message_id"`
-	Result    QueueResult `json:"result"`
+	MessageId string          `json:"message_id"`
+	Type      string          `json:"type"`
+	Ok        bool            `json:"ok"`
+	Payload   json.RawMessage `json:"payload"`
 }
 
 type QueueResult struct {
 	Success     bool              `json:"Success"`
 	StatusCode  int64             `json:"StatusCode"`
-	Code        string            `json:"Code"`
 	Message     string            `json:"Message"`
 	TestResults []QueueTestResult `json:"TestResults"`
+}
+
+type TaskResponsePayload struct {
+	Success    bool   `json:"Success"`
+	StatusCode int64  `json:"StatusCode"`
+	Message    string `json:"Message"`
+	TestResults []QueueTestResult `json:"TestResults"`
+}
+
+type HandShakeResponsePayload struct {
+	Languages []struct {
+		Name   string `json:"name"`
+		Versions []string `json:"versions"`
+	} `json:"languages"`
+}
+
+type StatusResponsePayload struct {
+	BusyWorkers   int               `json:"busy_workers"`
+	TotalWorkers  int               `json:"total_workers"`
+	WorkerStatus  map[string]string `json:"worker_status"`
 }
 
 type QueueTestResult struct {

--- a/package/domain/schemas/queue.go
+++ b/package/domain/schemas/queue.go
@@ -17,23 +17,23 @@ type QueueResult struct {
 }
 
 type TaskResponsePayload struct {
-	Success    bool   `json:"Success"`
-	StatusCode int64  `json:"StatusCode"`
-	Message    string `json:"Message"`
+	Success     bool              `json:"Success"`
+	StatusCode  int64             `json:"StatusCode"`
+	Message     string            `json:"Message"`
 	TestResults []QueueTestResult `json:"TestResults"`
 }
 
 type HandShakeResponsePayload struct {
 	Languages []struct {
-		Name   string `json:"name"`
+		Name     string   `json:"name"`
 		Versions []string `json:"versions"`
 	} `json:"languages"`
 }
 
 type StatusResponsePayload struct {
-	BusyWorkers   int               `json:"busy_workers"`
-	TotalWorkers  int               `json:"total_workers"`
-	WorkerStatus  map[string]string `json:"worker_status"`
+	BusyWorkers  int               `json:"busy_workers"`
+	TotalWorkers int               `json:"total_workers"`
+	WorkerStatus map[string]string `json:"worker_status"`
 }
 
 type QueueTestResult struct {

--- a/package/domain/schemas/queue_message.go
+++ b/package/domain/schemas/queue_message.go
@@ -13,13 +13,13 @@ type QueueMessage struct {
 }
 
 type TaskQueueMessage struct {
-	TaskID           int64  `json:"task_id"`
-	UserID           int64  `json:"user_id"`
-	SubmissionNumber int64  `json:"submission_number"`
-	LanguageType     string `json:"language_type"`
-	LanguageVersion  string `json:"language_version"`
-	TimeLimits       []int64  `json:"time_limits"`
-	MemoryLimits     []int64  `json:"memory_limits"`
-	ChrootDirPath    string `json:"chroot_dir_path,omitempty"` // Optional for test purposes
-	UseChroot        string `json:"use_chroot,omitempty"`      // Optional for test purposes
+	TaskID           int64   `json:"task_id"`
+	UserID           int64   `json:"user_id"`
+	SubmissionNumber int64   `json:"submission_number"`
+	LanguageType     string  `json:"language_type"`
+	LanguageVersion  string  `json:"language_version"`
+	TimeLimits       []int64 `json:"time_limits"`
+	MemoryLimits     []int64 `json:"memory_limits"`
+	ChrootDirPath    string  `json:"chroot_dir_path,omitempty"` // Optional for test purposes
+	UseChroot        string  `json:"use_chroot,omitempty"`      // Optional for test purposes
 }

--- a/package/domain/schemas/queue_message.go
+++ b/package/domain/schemas/queue_message.go
@@ -4,6 +4,9 @@ import "encoding/json"
 
 const (
 	SubmissionStatusQueued = "queued"
+	MessageTypeTask        = "task"
+	MessageTypeHandshake   = "handshake"
+	MessageTypeStatus      = "status"
 )
 
 type QueueMessage struct {

--- a/package/domain/schemas/queue_message.go
+++ b/package/domain/schemas/queue_message.go
@@ -1,16 +1,25 @@
 package schemas
 
+import "encoding/json"
+
 const (
 	SubmissionStatusQueued = "queued"
 )
 
 type QueueMessage struct {
-	MessageId       string    `json:"message_id"`
-	TaskId          int64     `json:"task_id"`
-	UserId          int64     `json:"user_id"`
-	SumissionNumber int64     `json:"submission_number"`
-	LanguageType    string    `json:"language_type"`
-	LanguageVersion string    `json:"language_version"`
-	TimeLimits      []float64 `json:"time_limits"`
-	MemoryLimits    []float64 `json:"memory_limits"`
+	Type      string          `json:"type"`
+	MessageID string          `json:"message_id"`
+	Payload   json.RawMessage `json:"payload"`
+}
+
+type TaskQueueMessage struct {
+	TaskID           int64  `json:"task_id"`
+	UserID           int64  `json:"user_id"`
+	SubmissionNumber int64  `json:"submission_number"`
+	LanguageType     string `json:"language_type"`
+	LanguageVersion  string `json:"language_version"`
+	TimeLimits       []int64  `json:"time_limits"`
+	MemoryLimits     []int64  `json:"memory_limits"`
+	ChrootDirPath    string `json:"chroot_dir_path,omitempty"` // Optional for test purposes
+	UseChroot        string `json:"use_chroot,omitempty"`      // Optional for test purposes
 }

--- a/package/repository/language_repository.go
+++ b/package/repository/language_repository.go
@@ -10,6 +10,9 @@ type LanguageRepository interface {
 	GetLanguage(tx *gorm.DB, languageId int64) (*models.LanguageConfig, error)
 	CreateLanguage(tx *gorm.DB, language *models.LanguageConfig) error
 	DeleteLanguage(tx *gorm.DB, languageId int64) error
+	MarkLanguageDisabled(tx *gorm.DB, languageId int64) error
+	MarkLanguageEnabled(tx *gorm.DB, languageId int64) error
+	GetEnabledLanguages(tx *gorm.DB) ([]models.LanguageConfig, error)
 }
 
 type languageRepository struct {
@@ -36,6 +39,25 @@ func (l *languageRepository) CreateLanguage(tx *gorm.DB, language *models.Langua
 func (l *languageRepository) DeleteLanguage(tx *gorm.DB, languageId int64) error {
 	err := tx.Model(&models.LanguageConfig{}).Where("id = ?", languageId).Delete(&models.LanguageConfig{}).Error
 	return err
+}
+
+func (l *languageRepository) MarkLanguageDisabled(tx *gorm.DB, languageId int64) error {
+	err := tx.Model(&models.LanguageConfig{}).Where("id = ?", languageId).Update("enabled", false).Error
+	return err
+}
+
+func (l *languageRepository) MarkLanguageEnabled(tx *gorm.DB, languageId int64) error {
+	err := tx.Model(&models.LanguageConfig{}).Where("id = ?", languageId).Update("enabled", true).Error
+	return err
+}
+
+func (l *languageRepository) GetEnabledLanguages(tx *gorm.DB) ([]models.LanguageConfig, error) {
+	tasks := []models.LanguageConfig{}
+	err := tx.Model(&models.LanguageConfig{}).Where("enabled = ?", true).Find(&tasks).Error
+	if err != nil {
+		return nil, err
+	}
+	return tasks, nil
 }
 
 func NewLanguageRepository(db *gorm.DB) (LanguageRepository, error) {

--- a/package/repository/language_repository.go
+++ b/package/repository/language_repository.go
@@ -41,19 +41,20 @@ func (l *languageRepository) DeleteLanguage(tx *gorm.DB, languageId int64) error
 	return err
 }
 
+
 func (l *languageRepository) MarkLanguageDisabled(tx *gorm.DB, languageId int64) error {
-	err := tx.Model(&models.LanguageConfig{}).Where("id = ?", languageId).Update("enabled", false).Error
+	err := tx.Model(&models.LanguageConfig{}).Where("id = ?", languageId).Update("disabled", true).Error
 	return err
 }
 
 func (l *languageRepository) MarkLanguageEnabled(tx *gorm.DB, languageId int64) error {
-	err := tx.Model(&models.LanguageConfig{}).Where("id = ?", languageId).Update("enabled", true).Error
+	err := tx.Model(&models.LanguageConfig{}).Where("id = ?", languageId).Update("disabled", false).Error
 	return err
 }
 
 func (l *languageRepository) GetEnabledLanguages(tx *gorm.DB) ([]models.LanguageConfig, error) {
 	tasks := []models.LanguageConfig{}
-	err := tx.Model(&models.LanguageConfig{}).Where("enabled = ?", true).Find(&tasks).Error
+	err := tx.Model(&models.LanguageConfig{}).Where("disabled = ?", false).Find(&tasks).Error
 	if err != nil {
 		return nil, err
 	}

--- a/package/repository/language_repository.go
+++ b/package/repository/language_repository.go
@@ -41,7 +41,6 @@ func (l *languageRepository) DeleteLanguage(tx *gorm.DB, languageId int64) error
 	return err
 }
 
-
 func (l *languageRepository) MarkLanguageDisabled(tx *gorm.DB, languageId int64) error {
 	err := tx.Model(&models.LanguageConfig{}).Where("id = ?", languageId).Update("disabled", true).Error
 	return err

--- a/package/repository/task_repository.go
+++ b/package/repository/task_repository.go
@@ -23,8 +23,8 @@ type TaskRepository interface {
 	GetAllTasks(tx *gorm.DB, limit, offset int, sort string) ([]models.Task, error)
 	GetAllForGroup(tx *gorm.DB, groupId int64, limit, offset int, sort string) ([]models.Task, error)
 	GetTaskByTitle(tx *gorm.DB, title string) (*models.Task, error)
-	GetTaskTimeLimits(tx *gorm.DB, taskId int64) ([]float64, error)
-	GetTaskMemoryLimits(tx *gorm.DB, taskId int64) ([]float64, error)
+	GetTaskTimeLimits(tx *gorm.DB, taskId int64) ([]int64, error)
+	GetTaskMemoryLimits(tx *gorm.DB, taskId int64) ([]int64, error)
 	EditTask(tx *gorm.DB, taskId int64, task *models.Task) error
 	DeleteTask(tx *gorm.DB, taskId int64) error
 }
@@ -194,28 +194,28 @@ func (tr *taskRepository) GetAllForGroup(tx *gorm.DB, groupId int64, limit, offs
 	return tasks, nil
 }
 
-func (tr *taskRepository) GetTaskTimeLimits(tx *gorm.DB, taskId int64) ([]float64, error) {
+func (tr *taskRepository) GetTaskTimeLimits(tx *gorm.DB, taskId int64) ([]int64, error) {
 	input_outputs := []models.InputOutput{}
 	err := tx.Model(&models.InputOutput{}).Where("task_id = ?", taskId).Find(&input_outputs).Error
 	if err != nil {
 		return nil, err
 	}
 	// Sort by order
-	timeLimits := make([]float64, len(input_outputs))
+	timeLimits := make([]int64, len(input_outputs))
 	for _, input_output := range input_outputs {
 		timeLimits[input_output.Order-1] = input_output.TimeLimit
 	}
 	return timeLimits, nil
 }
 
-func (tr *taskRepository) GetTaskMemoryLimits(tx *gorm.DB, taskId int64) ([]float64, error) {
+func (tr *taskRepository) GetTaskMemoryLimits(tx *gorm.DB, taskId int64) ([]int64, error) {
 	input_outputs := []models.InputOutput{}
 	err := tx.Model(&models.InputOutput{}).Where("task_id = ?", taskId).Find(&input_outputs).Error
 	if err != nil {
 		return nil, err
 	}
 	// Sort by order
-	memoryLimits := make([]float64, len(input_outputs))
+	memoryLimits := make([]int64, len(input_outputs))
 	for _, input_output := range input_outputs {
 		memoryLimits[input_output.Order-1] = input_output.MemoryLimit
 	}

--- a/package/service/submission_service.go
+++ b/package/service/submission_service.go
@@ -328,7 +328,7 @@ func (us *submissionService) CreateSubmissionResult(tx *gorm.DB, submissionId in
 }
 
 func (ss *submissionService) GetAvailableLanguages(tx *gorm.DB) ([]schemas.LanguageConfig, error) {
-	languages, err := ss.languageService.GetAll(tx)
+	languages, err := ss.languageService.GetAllEnabled(tx)
 	if err != nil {
 		ss.logger.Errorf("Error getting all languages: %v", err.Error())
 		return nil, err


### PR DESCRIPTION
Changes made to enable worker new queue messages handling, worker backend language synchronization, and worker status message (should admin have some endpoints to get the status of workers?)

This pull request includes several changes to the `docs`, `internal/api`, and `internal/config` files to improve the overall functionality and structure of the codebase. The most important changes include adding new fields to the documentation, updating the `UserRegisterRequest` schema, adding new methods to the `GroupRoute` interface, and enhancing the queue listener to handle different message types.

Documentation updates:

* [`docs/docs.go`](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4R2120-R2125): Added `group_ids` field and changed `confirmPassword` to `confirm_password` in the `UserRegisterRequest` schema. [[1]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4R2120-R2125) [[2]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4L2239-R2253)
* [`docs/swagger.md`](diffhunk://#diff-0d3265e8be331704b75414619e8cf0fcf63cdce0bcb13ae1df64cf99e8e42b20R2696): Updated the documentation to reflect the changes in the `UserRegisterRequest` schema and added `group_ids` field. [[1]](diffhunk://#diff-0d3265e8be331704b75414619e8cf0fcf63cdce0bcb13ae1df64cf99e8e42b20R2696) [[2]](diffhunk://#diff-0d3265e8be331704b75414619e8cf0fcf63cdce0bcb13ae1df64cf99e8e42b20L2817-R2818)
* [`docs/swagger.yaml`](diffhunk://#diff-85eaca9ed102c8ed649c4530f717cb96f291fb43486c47ff5075f5869cc00583R245-R248): Added `group_ids` field and changed `confirmPassword` to `confirm_password` in the `UserRegisterRequest` schema. [[1]](diffhunk://#diff-85eaca9ed102c8ed649c4530f717cb96f291fb43486c47ff5075f5869cc00583R245-R248) [[2]](diffhunk://#diff-85eaca9ed102c8ed649c4530f717cb96f291fb43486c47ff5075f5869cc00583L324-R328) [[3]](diffhunk://#diff-85eaca9ed102c8ed649c4530f717cb96f291fb43486c47ff5075f5869cc00583L345-R349)

Group route enhancements:

* [`internal/api/http/routes/group.go`](diffhunk://#diff-09e6d96f05afd29e160f8b043a3c486f4ba678aab12bdf7709299a3bfbbc087dR23-R25): Added `DeleteUsersFromGroup` and `GetGroupTasks` methods to the `GroupRoute` interface and implemented these methods in `GroupRouteImpl`. [[1]](diffhunk://#diff-09e6d96f05afd29e160f8b043a3c486f4ba678aab12bdf7709299a3bfbbc087dR23-R25) [[2]](diffhunk://#diff-09e6d96f05afd29e160f8b043a3c486f4ba678aab12bdf7709299a3bfbbc087dL278-R283) [[3]](diffhunk://#diff-09e6d96f05afd29e160f8b043a3c486f4ba678aab12bdf7709299a3bfbbc087dR309-R377) [[4]](diffhunk://#diff-09e6d96f05afd29e160f8b043a3c486f4ba678aab12bdf7709299a3bfbbc087dR432-R474) [[5]](diffhunk://#diff-09e6d96f05afd29e160f8b043a3c486f4ba678aab12bdf7709299a3bfbbc087dR501-R510)

Queue listener improvements:

* [`internal/api/queue/queue_listener.go`](diffhunk://#diff-5d82c39c5781cb307554a989ee3d449ac6b043499a6ac85928d1439bdffaf2b6R29-R39): Added support for handling `task`, `handshake`, and `status` message types in the queue listener. [[1]](diffhunk://#diff-5d82c39c5781cb307554a989ee3d449ac6b043499a6ac85928d1439bdffaf2b6R29-R39) [[2]](diffhunk://#diff-5d82c39c5781cb307554a989ee3d449ac6b043499a6ac85928d1439bdffaf2b6L45-R50) [[3]](diffhunk://#diff-5d82c39c5781cb307554a989ee3d449ac6b043499a6ac85928d1439bdffaf2b6R71) [[4]](diffhunk://#diff-5d82c39c5781cb307554a989ee3d449ac6b043499a6ac85928d1439bdffaf2b6R168-R170) [[5]](diffhunk://#diff-5d82c39c5781cb307554a989ee3d449ac6b043499a6ac85928d1439bdffaf2b6L172-R193) [[6]](diffhunk://#diff-5d82c39c5781cb307554a989ee3d449ac6b043499a6ac85928d1439bdffaf2b6R226-R290)

Configuration cleanup:

* [`internal/config/config.go`](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdL5-L10): Removed unused language configuration variables and simplified the `Config` struct. [[1]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdL5-L10) [[2]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdL21-L22) [[3]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdL58-L140) [[4]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdL269)

Test updates:

* [`internal/api/http/routes/auth_test.go`](diffhunk://#diff-f23cdec5e9aea71252d27fae189ac18fea53324844a178af3306f4da74825b62L234-R235): Updated the `TestRegister` function to include `ConfirmPassword` field. [[1]](diffhunk://#diff-f23cdec5e9aea71252d27fae189ac18fea53324844a178af3306f4da74825b62L234-R235) [[2]](diffhunk://#diff-f23cdec5e9aea71252d27fae189ac18fea53324844a178af3306f4da74825b62R265-R273) [[3]](diffhunk://#diff-f23cdec5e9aea71252d27fae189ac18fea53324844a178af3306f4da74825b62R282-R289)