### PR TITLE
chores: renamed functions

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -345,6 +345,69 @@ const docTemplate = `{
                         }
                     }
                 }
+            },
+            "delete": {
+                "description": "Delete users from a group",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "group"
+                ],
+                "summary": "Delete users from a group",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Group ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "User IDs",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/UserIds"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/ApiResponse-string"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/ApiError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/ApiError"
+                        }
+                    },
+                    "405": {
+                        "description": "Method Not Allowed",
+                        "schema": {
+                            "$ref": "#/definitions/ApiError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/ApiError"
+                        }
+                    }
+                }
             }
         },
         "/login": {
@@ -1926,7 +1989,9 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "name": {
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 50,
+                    "minLength": 3
                 }
             }
         },
@@ -1945,20 +2010,8 @@ const docTemplate = `{
                 "name": {
                     "type": "string"
                 },
-                "tasks": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Task"
-                    }
-                },
                 "updated_at": {
                     "type": "string"
-                },
-                "users": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/User"
-                    }
                 }
             }
         },
@@ -1972,7 +2025,7 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "language": {
-                    "$ref": "#/definitions/models.LanguageType"
+                    "type": "string"
                 },
                 "version": {
                     "type": "string"
@@ -2090,6 +2143,9 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "title": {
+                    "type": "string"
+                },
+                "updated_at": {
                     "type": "string"
                 }
             }
@@ -2216,7 +2272,7 @@ const docTemplate = `{
         "UserIds": {
             "type": "object",
             "properties": {
-                "user_ids": {
+                "userIds": {
                     "type": "array",
                     "items": {
                         "type": "integer"
@@ -2288,17 +2344,6 @@ const docTemplate = `{
                     "type": "string"
                 }
             }
-        },
-        "models.LanguageType": {
-            "type": "string",
-            "enum": [
-                "c",
-                "cpp"
-            ],
-            "x-enum-varnames": [
-                "LangTypeC",
-                "LangTypeCPP"
-            ]
         },
         "types.UserRole": {
             "type": "string",

--- a/docs/swagger.md
+++ b/docs/swagger.md
@@ -42,6 +42,7 @@ This is the API documentation for the Mini Maxit API.
 
 | Method  | URI     | Name   | Summary |
 |---------|---------|--------|---------|
+| DELETE | /api/v1/group/{id}/users | [delete group ID users](#delete-group-id-users) | Delete users from a group |
 | GET | /api/v1/group | [get group](#get-group) | Get all groups |
 | GET | /api/v1/group/{id} | [get group ID](#get-group-id) | Get a group |
 | GET | /api/v1/group/{id}/users | [get group ID users](#get-group-id-users) | Get users in a group |
@@ -103,6 +104,84 @@ This is the API documentation for the Mini Maxit API.
 
 
 ## Paths
+
+### <span id="delete-group-id-users"></span> Delete users from a group (*DeleteGroupIDUsers*)
+
+```
+DELETE /api/v1/group/{id}/users
+```
+
+Delete users from a group
+
+#### Consumes
+  * application/json
+
+#### Produces
+  * application/json
+
+#### Parameters
+
+| Name | Source | Type | Go type | Separator | Required | Default | Description |
+|------|--------|------|---------|-----------| :------: |---------|-------------|
+| id | `path` | integer | `int64` |  | ✓ |  | Group ID |
+| body | `body` | [UserIds](#user-ids) | `models.UserIds` | | ✓ | | User IDs |
+
+#### All responses
+| Code | Status | Description | Has headers | Schema |
+|------|--------|-------------|:-----------:|--------|
+| [200](#delete-group-id-users-200) | OK | OK |  | [schema](#delete-group-id-users-200-schema) |
+| [400](#delete-group-id-users-400) | Bad Request | Bad Request |  | [schema](#delete-group-id-users-400-schema) |
+| [403](#delete-group-id-users-403) | Forbidden | Forbidden |  | [schema](#delete-group-id-users-403-schema) |
+| [405](#delete-group-id-users-405) | Method Not Allowed | Method Not Allowed |  | [schema](#delete-group-id-users-405-schema) |
+| [500](#delete-group-id-users-500) | Internal Server Error | Internal Server Error |  | [schema](#delete-group-id-users-500-schema) |
+
+#### Responses
+
+
+##### <span id="delete-group-id-users-200"></span> 200 - OK
+Status: OK
+
+###### <span id="delete-group-id-users-200-schema"></span> Schema
+   
+  
+
+[APIResponseString](#api-response-string)
+
+##### <span id="delete-group-id-users-400"></span> 400 - Bad Request
+Status: Bad Request
+
+###### <span id="delete-group-id-users-400-schema"></span> Schema
+   
+  
+
+[APIError](#api-error)
+
+##### <span id="delete-group-id-users-403"></span> 403 - Forbidden
+Status: Forbidden
+
+###### <span id="delete-group-id-users-403-schema"></span> Schema
+   
+  
+
+[APIError](#api-error)
+
+##### <span id="delete-group-id-users-405"></span> 405 - Method Not Allowed
+Status: Method Not Allowed
+
+###### <span id="delete-group-id-users-405-schema"></span> Schema
+   
+  
+
+[APIError](#api-error)
+
+##### <span id="delete-group-id-users-500"></span> 500 - Internal Server Error
+Status: Internal Server Error
+
+###### <span id="delete-group-id-users-500-schema"></span> Schema
+   
+  
+
+[APIError](#api-error)
 
 ### <span id="delete-task-id"></span> Delete a task (*DeleteTaskID*)
 
@@ -2540,9 +2619,7 @@ Status: Internal Server Error
 | created_by | integer| `int64` |  | |  |  |
 | id | integer| `int64` |  | |  |  |
 | name | string| `string` |  | |  |  |
-| tasks | [][Task](#task)| `[]*Task` |  | |  |  |
 | updated_at | string| `string` |  | |  |  |
-| users | [][User](#user)| `[]*User` |  | |  |  |
 
 
 
@@ -2559,7 +2636,7 @@ Status: Internal Server Error
 |------|------|---------|:--------:| ------- |-------------|---------|
 | file_extension | string| `string` |  | |  |  |
 | id | integer| `int64` |  | |  |  |
-| language | [ModelsLanguageType](#models-language-type)| `ModelsLanguageType` |  | |  |  |
+| language | string| `string` |  | |  |  |
 | version | string| `string` |  | |  |  |
 
 
@@ -2660,6 +2737,7 @@ Status: Internal Server Error
 | created_by | integer| `int64` |  | |  |  |
 | id | integer| `int64` |  | |  |  |
 | title | string| `string` |  | |  |  |
+| updated_at | string| `string` |  | |  |  |
 
 
 
@@ -2784,7 +2862,7 @@ Status: Internal Server Error
 
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
-| user_ids | []integer| `[]int64` |  | |  |  |
+| userIds | []integer| `[]int64` |  | |  |  |
 
 
 
@@ -2837,17 +2915,6 @@ Status: Internal Server Error
 |------|------|---------|:--------:| ------- |-------------|---------|
 | code | string| `string` |  | |  |  |
 | message | string| `string` |  | |  |  |
-
-
-
-### <span id="models-language-type"></span> models.LanguageType
-
-
-  
-
-| Name | Type | Go type | Default | Description | Example |
-|------|------|---------| ------- |-------------|---------|
-| models.LanguageType | string| string | |  |  |
 
 
 

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -118,6 +118,8 @@ definitions:
   EditGroup:
     properties:
       name:
+        maxLength: 50
+        minLength: 3
         type: string
     type: object
   Group:
@@ -130,16 +132,8 @@ definitions:
         type: integer
       name:
         type: string
-      tasks:
-        items:
-          $ref: '#/definitions/Task'
-        type: array
       updated_at:
         type: string
-      users:
-        items:
-          $ref: '#/definitions/User'
-        type: array
     type: object
   LanguageConfig:
     properties:
@@ -148,7 +142,7 @@ definitions:
       id:
         type: integer
       language:
-        $ref: '#/definitions/models.LanguageType'
+        type: string
       version:
         type: string
     type: object
@@ -225,6 +219,8 @@ definitions:
       id:
         type: integer
       title:
+        type: string
+      updated_at:
         type: string
     type: object
   TaskCreateResponse:
@@ -308,7 +304,7 @@ definitions:
     type: object
   UserIds:
     properties:
-      user_ids:
+      userIds:
         items:
           type: integer
         type: array
@@ -360,14 +356,6 @@ definitions:
       message:
         type: string
     type: object
-  models.LanguageType:
-    enum:
-    - c
-    - cpp
-    type: string
-    x-enum-varnames:
-    - LangTypeC
-    - LangTypeCPP
   types.UserRole:
     enum:
     - student
@@ -529,6 +517,48 @@ paths:
       tags:
       - group
   /group/{id}/users:
+    delete:
+      consumes:
+      - application/json
+      description: Delete users from a group
+      parameters:
+      - description: Group ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      - description: User IDs
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/UserIds'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/ApiResponse-string'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/ApiError'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/ApiError'
+        "405":
+          description: Method Not Allowed
+          schema:
+            $ref: '#/definitions/ApiError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/ApiError'
+      summary: Delete users from a group
+      tags:
+      - group
     get:
       description: Get users in a group
       parameters:

--- a/internal/api/http/httputils/routes_utils.go
+++ b/internal/api/http/httputils/routes_utils.go
@@ -55,8 +55,8 @@ func ReturnSuccess(w http.ResponseWriter, statusCode int, data any) {
 		return
 	}
 }
-func GetQueryParams(query *url.Values) (map[string]interface{}, error) {
-	queryParams := map[string]interface{}{}
+func GetQueryParams(query *url.Values) (map[string]any, error) {
+	queryParams := map[string]any{}
 	for key, value := range *query {
 		if len(value) > 1 {
 			err := QueryError{Filed: key, Detail: MultipleQueryValues}
@@ -125,7 +125,7 @@ func SaveMultiPartFile(file multipart.File, handler *multipart.FileHeader) (stri
 }
 
 // ShouldBindJSON binds the request body to a struct and validates it.
-func ShouldBindJSON(body io.ReadCloser, v interface{}) error {
+func ShouldBindJSON(body io.ReadCloser, v any) error {
 	dec := json.NewDecoder(body)
 	dec.DisallowUnknownFields()
 

--- a/internal/api/http/middleware/session.go
+++ b/internal/api/http/middleware/session.go
@@ -22,7 +22,7 @@ func SessionValidationMiddleware(next http.Handler, db database.Database, sessio
 			httputils.ReturnError(w, http.StatusInternalServerError, "Failed to start transaction. "+err.Error())
 			return
 		}
-		sessionResponse, err := sessionService.ValidateSession(tx, sessionHeader)
+		sessionResponse, err := sessionService.Validate(tx, sessionHeader)
 		if err != nil {
 			if err == service.ErrSessionNotFound {
 				httputils.ReturnError(w, http.StatusUnauthorized, "Session not found")

--- a/internal/api/http/routes/auth_test.go
+++ b/internal/api/http/routes/auth_test.go
@@ -46,7 +46,7 @@ func TestLogin(t *testing.T) {
 
 	t.Run("Invalid request body", func(t *testing.T) {
 		tt := []struct {
-			body interface{}
+			body any
 			msg  string
 		}{
 			{
@@ -250,7 +250,7 @@ func TestRegister(t *testing.T) {
 	})
 
 	t.Run("Invalid request body", func(t *testing.T) {
-		tt := []interface{}{
+		tt := []any{
 			struct {
 				Email string `json:"email"`
 			}{

--- a/internal/api/http/routes/group.go
+++ b/internal/api/http/routes/group.go
@@ -69,7 +69,7 @@ func (gr *GroupRouteImpl) CreateGroup(w http.ResponseWriter, r *http.Request) {
 		Name:      request.Name,
 		CreatedBy: current_user.Id,
 	}
-	groupId, err := gr.groupService.CreateGroup(tx, current_user, group)
+	groupId, err := gr.groupService.Create(tx, current_user, group)
 	if err != nil {
 		db.Rollback()
 		status := http.StatusInternalServerError
@@ -122,7 +122,7 @@ func (gr *GroupRouteImpl) GetGroup(w http.ResponseWriter, r *http.Request) {
 
 	current_user := r.Context().Value(httputils.UserKey).(schemas.User)
 
-	group, err := gr.groupService.GetGroup(tx, current_user, groupId)
+	group, err := gr.groupService.Get(tx, current_user, groupId)
 	if err != nil {
 		db.Rollback()
 		status := http.StatusInternalServerError
@@ -161,10 +161,10 @@ func (gr *GroupRouteImpl) GetAllGroup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	queryParams := r.Context().Value(httputils.QueryParamsKey).(map[string]interface{})
+	queryParams := r.Context().Value(httputils.QueryParamsKey).(map[string]any)
 	current_user := r.Context().Value(httputils.UserKey).(schemas.User)
 
-	groups, err := gr.groupService.GetAllGroup(tx, current_user, queryParams)
+	groups, err := gr.groupService.GetAll(tx, current_user, queryParams)
 	if err != nil {
 		db.Rollback()
 		status := http.StatusInternalServerError
@@ -293,7 +293,7 @@ func (gr *GroupRouteImpl) AddUsersToGroup(w http.ResponseWriter, r *http.Request
 
 	current_user := r.Context().Value(httputils.UserKey).(schemas.User)
 
-	err = gr.groupService.AddUsersToGroup(tx, current_user, groupId, request.UserIds)
+	err = gr.groupService.AddUsers(tx, current_user, groupId, request.UserIds)
 	if err != nil {
 		db.Rollback()
 		status := http.StatusInternalServerError
@@ -355,7 +355,7 @@ func (gr *GroupRouteImpl) DeleteUsersFromGroup(w http.ResponseWriter, r *http.Re
 
 	current_user := r.Context().Value(httputils.UserKey).(schemas.User)
 
-	err = gr.groupService.DeleteUsersFromGroup(tx, current_user, groupId, request.UserIds)
+	err = gr.groupService.DeleteUsers(tx, current_user, groupId, request.UserIds)
 	if err != nil {
 		db.Rollback()
 		var status int
@@ -415,7 +415,7 @@ func (gr *GroupRouteImpl) GetGroupUsers(w http.ResponseWriter, r *http.Request) 
 
 	current_user := r.Context().Value(httputils.UserKey).(schemas.User)
 
-	users, err := gr.groupService.GetGroupUsers(tx, current_user, groupId)
+	users, err := gr.groupService.GetUsers(tx, current_user, groupId)
 	if err != nil {
 		db.Rollback()
 		status := http.StatusInternalServerError
@@ -456,7 +456,7 @@ func (gr *GroupRouteImpl) GetGroupTasks(w http.ResponseWriter, r *http.Request) 
 
 	current_user := r.Context().Value(httputils.UserKey).(schemas.User)
 
-	tasks, err := gr.groupService.GetGroupTasks(tx, current_user, groupId)
+	tasks, err := gr.groupService.GetTasks(tx, current_user, groupId)
 	if err != nil {
 		db.Rollback()
 		status := http.StatusInternalServerError

--- a/internal/api/http/routes/session.go
+++ b/internal/api/http/routes/session.go
@@ -44,7 +44,7 @@ func (sr *SessionRouteImpl) CreateSession(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	session, err := sr.sessionService.CreateSession(tx, request.UserId)
+	session, err := sr.sessionService.Create(tx, request.UserId)
 	if err != nil {
 		db.Rollback()
 		httputils.ReturnError(w, http.StatusInternalServerError, "Failed to create session. "+err.Error())
@@ -79,7 +79,7 @@ func (sr *SessionRouteImpl) ValidateSession(w http.ResponseWriter, r *http.Reque
 	}
 
 	var validateSession schemas.ValidateSessionResponse
-	validateSession, err = sr.sessionService.ValidateSession(tx, sessionToken)
+	validateSession, err = sr.sessionService.Validate(tx, sessionToken)
 	if err != nil {
 		db.Rollback()
 		if err == service.ErrSessionNotFound {
@@ -139,7 +139,7 @@ func (sr *SessionRouteImpl) InvalidateSession(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	err = sr.sessionService.InvalidateSession(tx, sessionToken)
+	err = sr.sessionService.Invalidate(tx, sessionToken)
 	if err != nil {
 		db.Rollback()
 		httputils.ReturnError(w, http.StatusInternalServerError, "Failed to invalidate session. "+err.Error())

--- a/internal/api/http/routes/submission.go
+++ b/internal/api/http/routes/submission.go
@@ -67,7 +67,7 @@ func (s *SumbissionImpl) GetAll(w http.ResponseWriter, r *http.Request) {
 
 	current_user := r.Context().Value(httputils.UserKey).(schemas.User)
 
-	queryParams := r.Context().Value(httputils.QueryParamsKey).(map[string]interface{})
+	queryParams := r.Context().Value(httputils.QueryParamsKey).(map[string]any)
 
 	submissions, err := s.submissionService.GetAll(tx, current_user, queryParams)
 	if err != nil {
@@ -118,7 +118,7 @@ func (s *SumbissionImpl) GetById(w http.ResponseWriter, r *http.Request) {
 
 	current_user := r.Context().Value(httputils.UserKey).(schemas.User)
 
-	submission, err := s.submissionService.GetById(tx, submissionId, current_user)
+	submission, err := s.submissionService.Get(tx, submissionId, current_user)
 	if err != nil {
 		db.Rollback()
 		httputils.ReturnError(w, http.StatusInternalServerError, "Failed to get submission. "+err.Error())
@@ -164,7 +164,7 @@ func (s *SumbissionImpl) GetAllForUser(w http.ResponseWriter, r *http.Request) {
 	}
 
 	current_user := r.Context().Value(httputils.UserKey).(schemas.User)
-	queryParams := r.Context().Value(httputils.QueryParamsKey).(map[string]interface{})
+	queryParams := r.Context().Value(httputils.QueryParamsKey).(map[string]any)
 
 	submissions, err := s.submissionService.GetAllForUser(tx, userId, current_user, queryParams)
 	if err != nil {
@@ -221,7 +221,7 @@ func (s *SumbissionImpl) GetAllForUserShort(w http.ResponseWriter, r *http.Reque
 	}
 
 	current_user := r.Context().Value(httputils.UserKey).(schemas.User)
-	queryParams := r.Context().Value(httputils.QueryParamsKey).(map[string]interface{})
+	queryParams := r.Context().Value(httputils.QueryParamsKey).(map[string]any)
 
 	submissions, err := s.submissionService.GetAllForUserShort(tx, userId, current_user, queryParams)
 	if err != nil {
@@ -279,7 +279,7 @@ func (s *SumbissionImpl) GetAllForGroup(w http.ResponseWriter, r *http.Request) 
 
 	current_user := r.Context().Value(httputils.UserKey).(schemas.User)
 
-	queryParams := r.Context().Value(httputils.QueryParamsKey).(map[string]interface{})
+	queryParams := r.Context().Value(httputils.QueryParamsKey).(map[string]any)
 
 	submissions, err := s.submissionService.GetAllForGroup(tx, groupId, current_user, queryParams)
 	if err != nil {
@@ -332,7 +332,7 @@ func (s *SumbissionImpl) GetAllForTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	queryParams := r.Context().Value(httputils.QueryParamsKey).(map[string]interface{})
+	queryParams := r.Context().Value(httputils.QueryParamsKey).(map[string]any)
 
 	submissions, err := s.submissionService.GetAllForTask(tx, taskId, current_user, queryParams)
 	if err != nil {
@@ -446,7 +446,7 @@ func (s *SumbissionImpl) SubmitSolution(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	_, err = s.taskService.GetTask(tx, current_user, taskId)
+	_, err = s.taskService.Get(tx, current_user, taskId)
 	if err != nil {
 		db.Rollback()
 		switch err {
@@ -516,7 +516,7 @@ func (s *SumbissionImpl) SubmitSolution(w http.ResponseWriter, r *http.Request) 
 	}
 
 	// Create the submission with the correct order
-	submissionId, err := s.submissionService.CreateSubmission(tx, taskId, userId, languageId, respJson.SubmissionNumber)
+	submissionId, err := s.submissionService.Create(tx, taskId, userId, languageId, respJson.SubmissionNumber)
 	if err != nil {
 		db.Rollback()
 		httputils.ReturnError(w, http.StatusInternalServerError, fmt.Sprintf("Error creating submission. %s", err.Error()))

--- a/internal/api/http/routes/task.go
+++ b/internal/api/http/routes/task.go
@@ -59,10 +59,10 @@ func (tr *TaskRouteImpl) GetAllAssingedTasks(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	queryParams := r.Context().Value(httputils.QueryParamsKey).(map[string]interface{})
+	queryParams := r.Context().Value(httputils.QueryParamsKey).(map[string]any)
 	current_user := r.Context().Value(httputils.UserKey).(schemas.User)
 
-	task, err := tr.taskService.GetAllAssignedTasks(tx, current_user, queryParams)
+	task, err := tr.taskService.GetAllAssigned(tx, current_user, queryParams)
 
 	if err != nil {
 		db.Rollback()
@@ -90,10 +90,10 @@ func (tr *TaskRouteImpl) GetAllCreatedTasks(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	queryParams := r.Context().Value(httputils.QueryParamsKey).(map[string]interface{})
+	queryParams := r.Context().Value(httputils.QueryParamsKey).(map[string]any)
 	current_user := r.Context().Value(httputils.UserKey).(schemas.User)
 
-	task, err := tr.taskService.GetAllCreatedTasks(tx, current_user, queryParams)
+	task, err := tr.taskService.GetAllCreated(tx, current_user, queryParams)
 	if err != nil {
 		db.Rollback()
 		status := http.StatusInternalServerError
@@ -134,7 +134,7 @@ func (tr *TaskRouteImpl) GetAllTasks(w http.ResponseWriter, r *http.Request) {
 	}
 
 	current_user := r.Context().Value(httputils.UserKey).(schemas.User)
-	queryParams := r.Context().Value(httputils.QueryParamsKey).(map[string]interface{})
+	queryParams := r.Context().Value(httputils.QueryParamsKey).(map[string]any)
 	tasks, err := tr.taskService.GetAll(tx, current_user, queryParams)
 	if err != nil {
 		db.Rollback()
@@ -192,7 +192,7 @@ func (tr *TaskRouteImpl) GetTask(w http.ResponseWriter, r *http.Request) {
 
 	current_user := r.Context().Value(httputils.UserKey).(schemas.User)
 
-	task, err := tr.taskService.GetTask(tx, current_user, taskId)
+	task, err := tr.taskService.Get(tx, current_user, taskId)
 	if err != nil {
 		db.Rollback()
 		status := http.StatusInternalServerError
@@ -245,7 +245,7 @@ func (tr *TaskRouteImpl) GetAllForGroup(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	queryParams := r.Context().Value(httputils.QueryParamsKey).(map[string]interface{})
+	queryParams := r.Context().Value(httputils.QueryParamsKey).(map[string]any)
 
 	current_user := r.Context().Value(httputils.UserKey).(schemas.User)
 
@@ -345,7 +345,7 @@ func (tr *TaskRouteImpl) UploadTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = tr.taskService.ProcessAndUploadTask(tx, currentUser, taskId, filePath)
+	err = tr.taskService.ProcessAndUpload(tx, currentUser, taskId, filePath)
 	if err != nil {
 		db.Rollback()
 		httputils.ReturnError(w, http.StatusInternalServerError, fmt.Sprintf("Error processing and uploading task. %s", err.Error()))
@@ -404,7 +404,7 @@ func (tr *TaskRouteImpl) EditTask(w http.ResponseWriter, r *http.Request) {
 		request.Title = &newTitle
 	}
 
-	err = tr.taskService.EditTask(tx, current_user, taskId, &request)
+	err = tr.taskService.Edit(tx, current_user, taskId, &request)
 	if err != nil {
 		db.Rollback()
 		status := http.StatusInternalServerError
@@ -434,7 +434,7 @@ func (tr *TaskRouteImpl) EditTask(w http.ResponseWriter, r *http.Request) {
 			httputils.ReturnError(w, http.StatusInternalServerError, fmt.Sprintf("Error saving multipart file. %s", err.Error()))
 			return
 		}
-		err = tr.taskService.ProcessAndUploadTask(tx, current_user, taskId, filePath)
+		err = tr.taskService.ProcessAndUpload(tx, current_user, taskId, filePath)
 		if err != nil {
 			db.Rollback()
 			httputils.ReturnError(w, http.StatusInternalServerError, fmt.Sprintf("Error processing and uploading task. %s", err.Error()))
@@ -484,7 +484,7 @@ func (tr *TaskRouteImpl) DeleteTask(w http.ResponseWriter, r *http.Request) {
 
 	current_user := r.Context().Value(httputils.UserKey).(schemas.User)
 
-	err = tr.taskService.DeleteTask(tx, current_user, taskId)
+	err = tr.taskService.Delete(tx, current_user, taskId)
 	if err != nil {
 		db.Rollback()
 		status := http.StatusInternalServerError
@@ -546,7 +546,7 @@ func (tr *TaskRouteImpl) AssignTaskToUsers(w http.ResponseWriter, r *http.Reques
 
 	current_user := r.Context().Value(httputils.UserKey).(schemas.User)
 
-	err = tr.taskService.AssignTaskToUsers(tx, current_user, taskId, request.UserIds)
+	err = tr.taskService.AssignToUsers(tx, current_user, taskId, request.UserIds)
 	if err != nil {
 		db.Rollback()
 		status := http.StatusInternalServerError
@@ -608,7 +608,7 @@ func (tr *TaskRouteImpl) AssignTaskToGroups(w http.ResponseWriter, r *http.Reque
 
 	current_user := r.Context().Value(httputils.UserKey).(schemas.User)
 
-	err = tr.taskService.AssignTaskToGroups(tx, current_user, taskId, request.GroupIds)
+	err = tr.taskService.AssignToGroups(tx, current_user, taskId, request.GroupIds)
 	if err != nil {
 		db.Rollback()
 		status := http.StatusInternalServerError
@@ -670,7 +670,7 @@ func (tr *TaskRouteImpl) UnAssignTaskFromUsers(w http.ResponseWriter, r *http.Re
 
 	current_user := r.Context().Value(httputils.UserKey).(schemas.User)
 
-	err = tr.taskService.UnAssignTaskFromUsers(tx, current_user, taskId, request.UserIds)
+	err = tr.taskService.UnassignFromUsers(tx, current_user, taskId, request.UserIds)
 	if err != nil {
 		db.Rollback()
 		status := http.StatusInternalServerError
@@ -732,7 +732,7 @@ func (tr *TaskRouteImpl) UnAssignTaskFromGroups(w http.ResponseWriter, r *http.R
 
 	current_user := r.Context().Value(httputils.UserKey).(schemas.User)
 
-	err = tr.taskService.UnAssignTaskFromGroups(tx, current_user, taskId, request.GroupIds)
+	err = tr.taskService.UnassignFromGroups(tx, current_user, taskId, request.GroupIds)
 	if err != nil {
 		db.Rollback()
 		status := http.StatusInternalServerError

--- a/internal/api/http/routes/user.go
+++ b/internal/api/http/routes/user.go
@@ -56,8 +56,8 @@ func (u *UserRouteImpl) GetAllUsers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	queryParams := r.Context().Value(httputils.QueryParamsKey).(map[string]interface{})
-	users, err := u.userService.GetAllUsers(tx, queryParams)
+	queryParams := r.Context().Value(httputils.QueryParamsKey).(map[string]any)
+	users, err := u.userService.GetAll(tx, queryParams)
 	if err != nil {
 		db.Rollback()
 		httputils.ReturnError(w, http.StatusInternalServerError, fmt.Sprintf("Error getting users. %s", err.Error()))
@@ -110,7 +110,7 @@ func (u *UserRouteImpl) GetUserById(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	user, err := u.userService.GetUserById(tx, userId)
+	user, err := u.userService.Get(tx, userId)
 	if err != nil {
 		db.Rollback()
 		if err == errors.ErrUserNotFound {
@@ -143,7 +143,7 @@ func (u *UserRouteImpl) GetUserByEmail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	queryParams := r.Context().Value(httputils.QueryParamsKey).(map[string]interface{})
+	queryParams := r.Context().Value(httputils.QueryParamsKey).(map[string]any)
 	email := queryParams["email"].(string)
 	if email == "" {
 		httputils.ReturnError(w, http.StatusBadRequest, "Email query cannot be empty")
@@ -157,7 +157,7 @@ func (u *UserRouteImpl) GetUserByEmail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	user, err := u.userService.GetUserByEmail(tx, email)
+	user, err := u.userService.GetByEmail(tx, email)
 	if err != nil {
 		db.Rollback()
 		if err == errors.ErrUserNotFound {
@@ -218,7 +218,7 @@ func (u *UserRouteImpl) EditUser(w http.ResponseWriter, r *http.Request) {
 
 	currentUser := r.Context().Value(httputils.UserKey).(schemas.User)
 
-	err = u.userService.EditUser(tx, currentUser, userId, &request)
+	err = u.userService.Edit(tx, currentUser, userId, &request)
 	if err != nil {
 		db.Rollback()
 		if err == errors.ErrNotAllowed {

--- a/internal/api/queue/queue_listener.go
+++ b/internal/api/queue/queue_listener.go
@@ -190,7 +190,7 @@ func (ql *QueueListenerImpl) processMessage(msg amqp.Delivery) {
 			return
 		}
 		if taskResponse.StatusCode == InternalError {
-			err = ql.submissionService.MarkSubmissionFailed(tx, submissionId, taskResponse.Message)
+			err = ql.submissionService.MarkFailed(tx, submissionId, taskResponse.Message)
 			if err != nil {
 				tx.Rollback()
 				err := msg.Reject(true)
@@ -201,7 +201,7 @@ func (ql *QueueListenerImpl) processMessage(msg amqp.Delivery) {
 			return
 		}
 
-		err = ql.submissionService.MarkSubmissionComplete(tx, submissionId)
+		err = ql.submissionService.MarkComplete(tx, submissionId)
 		if err != nil {
 			ql.logger.Errorf("Failed to mark submission as complete: %s", err.Error())
 			tx.Rollback()
@@ -238,7 +238,7 @@ func (ql *QueueListenerImpl) processMessage(msg amqp.Delivery) {
 			return
 		}
 
-		err := ql.languageService.InitLanguages(tx, handshakeResponse)
+		err := ql.languageService.Init(tx, handshakeResponse)
 		if err != nil {
 			ql.logger.Errorf("Failed to initialize languages: %s", err.Error())
 			tx.Rollback()

--- a/internal/initialization/initialization.go
+++ b/internal/initialization/initialization.go
@@ -142,7 +142,7 @@ func NewInitialization(cfg *config.Config) *Initialization {
 	authService := service.NewAuthService(userRepository, sessionService)
 	groupService := service.NewGroupService(groupRepository, userRepository, userService)
 	langService := service.NewLanguageService(langRepository)
-	submissionService := service.NewSubmissionService(submissionRepository, submissionResultRepository, inputOutputRepository, testResultRepository, langService, taskService, userService)
+	submissionService := service.NewSubmissionService(submissionRepository, submissionResultRepository, inputOutputRepository, testResultRepository, groupRepository, taskRepository, langService, taskService, userService)
 
 	// Routes
 	authRoute := routes.NewAuthRoute(userService, authService)

--- a/internal/testutils/mocks.go
+++ b/internal/testutils/mocks.go
@@ -28,7 +28,7 @@ func (ur *MockUserRepository) FailNext() {
 	ur.failNext = true
 }
 
-func (ur *MockUserRepository) CreateUser(tx *gorm.DB, user *models.User) (int64, error) {
+func (ur *MockUserRepository) Create(tx *gorm.DB, user *models.User) (int64, error) {
 	if ur.failNext {
 		ur.failNext = false
 		return 0, gorm.ErrInvalidDB
@@ -42,7 +42,7 @@ func (ur *MockUserRepository) CreateUser(tx *gorm.DB, user *models.User) (int64,
 	return ur.counter, nil
 }
 
-func (ur *MockUserRepository) GetUser(tx *gorm.DB, userId int64) (*models.User, error) {
+func (ur *MockUserRepository) Get(tx *gorm.DB, userId int64) (*models.User, error) {
 	if ur.failNext {
 		ur.failNext = false
 		return nil, gorm.ErrInvalidDB
@@ -55,7 +55,7 @@ func (ur *MockUserRepository) GetUser(tx *gorm.DB, userId int64) (*models.User, 
 	return nil, gorm.ErrRecordNotFound
 }
 
-func (ur *MockUserRepository) GetUserByEmail(tx *gorm.DB, email string) (*models.User, error) {
+func (ur *MockUserRepository) GetByEmail(tx *gorm.DB, email string) (*models.User, error) {
 	if tx == nil {
 		return nil, gorm.ErrInvalidDB
 	}
@@ -65,7 +65,7 @@ func (ur *MockUserRepository) GetUserByEmail(tx *gorm.DB, email string) (*models
 	return nil, gorm.ErrRecordNotFound
 }
 
-func (ur *MockUserRepository) GetAllUsers(tx *gorm.DB, limit, offset int, sort string) ([]models.User, error) {
+func (ur *MockUserRepository) GetAll(tx *gorm.DB, limit, offset int, sort string) ([]models.User, error) {
 	if tx == nil {
 		return nil, gorm.ErrInvalidDB
 	}
@@ -76,7 +76,7 @@ func (ur *MockUserRepository) GetAllUsers(tx *gorm.DB, limit, offset int, sort s
 	return users, nil
 }
 
-func (ur *MockUserRepository) EditUser(tx *gorm.DB, user *models.User) error {
+func (ur *MockUserRepository) Edit(tx *gorm.DB, user *models.User) error {
 	if tx == nil {
 		return gorm.ErrInvalidDB
 	}
@@ -115,12 +115,12 @@ func (sr *MockSessionRepository) FailNext() {
 	sr.failNext = true
 }
 
-func (sr *MockSessionRepository) CreateSession(tx *gorm.DB, session *models.Session) error {
+func (sr *MockSessionRepository) Create(tx *gorm.DB, session *models.Session) error {
 	sr.sessions[session.Id] = session
 	return nil
 }
 
-func (sr *MockSessionRepository) GetSession(tx *gorm.DB, sessionId string) (*models.Session, error) {
+func (sr *MockSessionRepository) Get(tx *gorm.DB, sessionId string) (*models.Session, error) {
 	if sr.failNext {
 		sr.failNext = false
 		return nil, gorm.ErrInvalidDB
@@ -131,7 +131,7 @@ func (sr *MockSessionRepository) GetSession(tx *gorm.DB, sessionId string) (*mod
 	return nil, gorm.ErrRecordNotFound
 }
 
-func (sr *MockSessionRepository) GetSessionByUserId(tx *gorm.DB, userId int64) (*models.Session, error) {
+func (sr *MockSessionRepository) GetByUserId(tx *gorm.DB, userId int64) (*models.Session, error) {
 	if sr.failNext {
 		log.Printf("Failing getsession by user id")
 		sr.failNext = false
@@ -153,7 +153,7 @@ func (sr *MockSessionRepository) UpdateExpiration(tx *gorm.DB, sessionId string,
 	return gorm.ErrRecordNotFound
 }
 
-func (sr *MockSessionRepository) DeleteSession(tx *gorm.DB, sessionId string) error {
+func (sr *MockSessionRepository) Delete(tx *gorm.DB, sessionId string) error {
 	delete(sr.sessions, sessionId)
 	return nil
 }
@@ -182,14 +182,14 @@ func (tr *MockTaskRepository) Create(tx *gorm.DB, task *models.Task) (int64, err
 	return task.Id, nil
 }
 
-func (tr *MockTaskRepository) GetTask(tx *gorm.DB, taskId int64) (*models.Task, error) {
+func (tr *MockTaskRepository) Get(tx *gorm.DB, taskId int64) (*models.Task, error) {
 	if task, ok := tr.tasks[taskId]; ok {
 		return task, nil
 	}
 	return nil, gorm.ErrRecordNotFound
 }
 
-func (tr *MockTaskRepository) GetAllTasks(tx *gorm.DB, limit, offset int, sort string) ([]models.Task, error) {
+func (tr *MockTaskRepository) GetAll(tx *gorm.DB, limit, offset int, sort string) ([]models.Task, error) {
 	tasks := make([]models.Task, 0, len(tr.tasks))
 	for _, task := range tr.tasks {
 		tasks = append(tasks, *task)
@@ -221,7 +221,7 @@ func (tr *MockTaskRepository) GetAllForGroup(tx *gorm.DB, groupId int64, limit, 
 	return tasks, nil
 }
 
-func (tr *MockTaskRepository) GetTaskByTitle(tx *gorm.DB, title string) (*models.Task, error) {
+func (tr *MockTaskRepository) GetByTitle(tx *gorm.DB, title string) (*models.Task, error) {
 	for _, task := range tr.tasks {
 		if task.Title == title {
 			return task, nil
@@ -230,7 +230,7 @@ func (tr *MockTaskRepository) GetTaskByTitle(tx *gorm.DB, title string) (*models
 	return nil, gorm.ErrRecordNotFound
 }
 
-func (tr *MockTaskRepository) GetTaskTimeLimits(tx *gorm.DB, taskId int64) ([]int64, error) {
+func (tr *MockTaskRepository) GetTimeLimits(tx *gorm.DB, taskId int64) ([]int64, error) {
 	panic("implement me")
 	// if task, ok := tr.tasks[taskId]; ok {
 	// 	return task.TimeLimits, nil
@@ -238,7 +238,7 @@ func (tr *MockTaskRepository) GetTaskTimeLimits(tx *gorm.DB, taskId int64) ([]in
 	// return nil, gorm.ErrRecordNotFound
 }
 
-func (tr *MockTaskRepository) GetTaskMemoryLimits(tx *gorm.DB, taskId int64) ([]int64, error) {
+func (tr *MockTaskRepository) GetMemoryLimits(tx *gorm.DB, taskId int64) ([]int64, error) {
 	panic("implement me")
 	// if task, ok := tr.tasks[taskId]; ok {
 	// 	return task.MemoryLimits, nil
@@ -251,7 +251,7 @@ func (tr *MockTaskRepository) Clear() {
 	tr.tasksCouter = 0
 }
 
-func (tr *MockTaskRepository) EditTask(tx *gorm.DB, taskId int64, task *models.Task) error {
+func (tr *MockTaskRepository) Edit(tx *gorm.DB, taskId int64, task *models.Task) error {
 	if _, ok := tr.tasks[taskId]; ok {
 		tr.tasks[taskId] = task
 		return nil
@@ -259,7 +259,7 @@ func (tr *MockTaskRepository) EditTask(tx *gorm.DB, taskId int64, task *models.T
 	return gorm.ErrRecordNotFound
 }
 
-func (tr *MockTaskRepository) DeleteTask(tx *gorm.DB, taskId int64) error {
+func (tr *MockTaskRepository) Delete(tx *gorm.DB, taskId int64) error {
 	if _, ok := tr.tasks[taskId]; ok {
 		delete(tr.tasks, taskId)
 		return nil
@@ -267,7 +267,7 @@ func (tr *MockTaskRepository) DeleteTask(tx *gorm.DB, taskId int64) error {
 	return gorm.ErrRecordNotFound
 }
 
-func (tr *MockTaskRepository) AssignTaskToUser(tx *gorm.DB, taskId, userId int64) error {
+func (tr *MockTaskRepository) AssignToUser(tx *gorm.DB, taskId, userId int64) error {
 	if _, ok := tr.tasks[taskId]; !ok {
 		return gorm.ErrRecordNotFound
 	}
@@ -285,7 +285,7 @@ func (tr *MockTaskRepository) AssignTaskToUser(tx *gorm.DB, taskId, userId int64
 	return nil
 }
 
-func (tr *MockTaskRepository) AssignTaskToGroup(tx *gorm.DB, taskId, groupId int64) error {
+func (tr *MockTaskRepository) AssignToGroup(tx *gorm.DB, taskId, groupId int64) error {
 	for _, taskGroup := range tr.taskGroups {
 		if taskGroup.TaskId == taskId && taskGroup.GroupId == groupId {
 			return nil
@@ -305,7 +305,7 @@ func (tr *MockTaskRepository) AssignTaskToGroup(tx *gorm.DB, taskId, groupId int
 	return nil
 }
 
-func (tr *MockTaskRepository) UnAssignTaskFromUser(tx *gorm.DB, taskId, userId int64) error {
+func (tr *MockTaskRepository) UnassignFromUser(tx *gorm.DB, taskId, userId int64) error {
 	for i, taskUser := range tr.taskUsers {
 		if taskUser.TaskId == taskId && taskUser.UserId == userId {
 			tr.taskUsers = append(tr.taskUsers[:i], tr.taskUsers[i+1:]...)
@@ -315,7 +315,7 @@ func (tr *MockTaskRepository) UnAssignTaskFromUser(tx *gorm.DB, taskId, userId i
 	return gorm.ErrRecordNotFound
 }
 
-func (tr *MockTaskRepository) UnAssignTaskFromGroup(tx *gorm.DB, taskId, groupId int64) error {
+func (tr *MockTaskRepository) UnassignFromGroup(tx *gorm.DB, taskId, groupId int64) error {
 	for i, taskGroup := range tr.taskGroups {
 		if taskGroup.TaskId == taskId && taskGroup.GroupId == groupId {
 			tr.taskGroups = append(tr.taskGroups[:i], tr.taskGroups[i+1:]...)
@@ -325,7 +325,7 @@ func (tr *MockTaskRepository) UnAssignTaskFromGroup(tx *gorm.DB, taskId, groupId
 	return gorm.ErrRecordNotFound
 }
 
-func (tr *MockTaskRepository) GetAllAssignedTasks(tx *gorm.DB, userId int64, limit, offset int, sort string) ([]models.Task, error) {
+func (tr *MockTaskRepository) GetAllAssigned(tx *gorm.DB, userId int64, limit, offset int, sort string) ([]models.Task, error) {
 	var tasks []models.Task
 	for _, taskUser := range tr.taskUsers {
 		if taskUser.UserId == userId {
@@ -357,7 +357,7 @@ func (tr *MockTaskRepository) GetAllAssignedTasks(tx *gorm.DB, userId int64, lim
 	return tasks, nil
 }
 
-func (tr *MockTaskRepository) GetAllCreatedTasks(tx *gorm.DB, userId int64, limit, offset int, sort string) ([]models.Task, error) {
+func (tr *MockTaskRepository) GetAllCreated(tx *gorm.DB, userId int64, limit, offset int, sort string) ([]models.Task, error) {
 	var tasks []models.Task
 	for _, task := range tr.tasks {
 		if task.CreatedBy == userId {
@@ -367,7 +367,7 @@ func (tr *MockTaskRepository) GetAllCreatedTasks(tx *gorm.DB, userId int64, limi
 	return tasks, nil
 }
 
-func (tr *MockTaskRepository) IsTaskAssignedToGroup(tx *gorm.DB, taskId, groupId int64) (bool, error) {
+func (tr *MockTaskRepository) IsAssignedToGroup(tx *gorm.DB, taskId, groupId int64) (bool, error) {
 	for _, taskGroup := range tr.taskGroups {
 		if taskGroup.TaskId == taskId && taskGroup.GroupId == groupId {
 			return true, nil
@@ -376,7 +376,7 @@ func (tr *MockTaskRepository) IsTaskAssignedToGroup(tx *gorm.DB, taskId, groupId
 	return false, nil
 }
 
-func (tr *MockTaskRepository) IsTaskAssignedToUser(tx *gorm.DB, taskId, userId int64) (bool, error) {
+func (tr *MockTaskRepository) IsAssignedToUser(tx *gorm.DB, taskId, userId int64) (bool, error) {
 	for _, taskUser := range tr.taskUsers {
 		if taskUser.TaskId == taskId && taskUser.UserId == userId {
 			return true, nil
@@ -423,7 +423,7 @@ type MockSubmissionRepository struct {
 	counter     int64
 }
 
-func (sr *MockSubmissionRepository) CreateSubmission(tx *gorm.DB, submission *models.Submission) (int64, error) {
+func (sr *MockSubmissionRepository) Create(tx *gorm.DB, submission *models.Submission) (int64, error) {
 	sr.counter++
 	submission.Id = sr.counter
 	sr.submissions[submission.Id] = submission
@@ -479,14 +479,14 @@ type MockGroupRepository struct {
 	userRepository *MockUserRepository
 }
 
-func (gr *MockGroupRepository) CreateGroup(tx *gorm.DB, group *models.Group) (int64, error) {
+func (gr *MockGroupRepository) Create(tx *gorm.DB, group *models.Group) (int64, error) {
 	gr.groupsCounter++
 	group.Id = gr.groupsCounter
 	gr.groups[group.Id] = group
 	return group.Id, nil
 }
 
-func (gr *MockGroupRepository) DeleteGroup(tx *gorm.DB, groupId int64) error {
+func (gr *MockGroupRepository) Delete(tx *gorm.DB, groupId int64) error {
 	if _, ok := gr.groups[groupId]; ok {
 		delete(gr.groups, groupId)
 		return nil
@@ -502,7 +502,7 @@ func (gr *MockGroupRepository) Edit(tx *gorm.DB, groupId int64, group *models.Gr
 	return nil, gorm.ErrRecordNotFound
 }
 
-func (gr *MockGroupRepository) GetAllGroup(*gorm.DB, int, int, string) ([]models.Group, error) {
+func (gr *MockGroupRepository) GetAll(*gorm.DB, int, int, string) ([]models.Group, error) {
 	groups := make([]models.Group, 0, len(gr.groups))
 	for _, group := range gr.groups {
 		groups = append(groups, *group)
@@ -510,7 +510,7 @@ func (gr *MockGroupRepository) GetAllGroup(*gorm.DB, int, int, string) ([]models
 	return groups, nil
 }
 
-func (gr *MockGroupRepository) GetGroup(tx *gorm.DB, groupId int64) (*models.Group, error) {
+func (gr *MockGroupRepository) Get(tx *gorm.DB, groupId int64) (*models.Group, error) {
 	if group, ok := gr.groups[groupId]; ok {
 		return group, nil
 	}
@@ -528,7 +528,7 @@ func (gr *MockGroupRepository) AddUsersToGroup(tx *gorm.DB, groupId int64, userI
 	return nil
 }
 
-func (gr *MockGroupRepository) AddUserToGroup(tx *gorm.DB, groupId int64, userId int64) error {
+func (gr *MockGroupRepository) AddUser(tx *gorm.DB, groupId int64, userId int64) error {
 	gr.userGroupsCounter++
 	gr.userGroups[gr.userGroupsCounter] = append(gr.userGroups[gr.userGroupsCounter], &models.UserGroup{
 		GroupId: groupId,
@@ -537,7 +537,7 @@ func (gr *MockGroupRepository) AddUserToGroup(tx *gorm.DB, groupId int64, userId
 	return nil
 }
 
-func (gr *MockGroupRepository) DeleteUserFromGroup(tx *gorm.DB, groupId int64, userId int64) error {
+func (gr *MockGroupRepository) DeleteUser(tx *gorm.DB, groupId int64, userId int64) error {
 	for i, userGroup := range gr.userGroups {
 		for j, ug := range userGroup {
 			if ug.GroupId == groupId && ug.UserId == userId {
@@ -549,7 +549,7 @@ func (gr *MockGroupRepository) DeleteUserFromGroup(tx *gorm.DB, groupId int64, u
 	return gorm.ErrRecordNotFound
 }
 
-func (gr *MockGroupRepository) GetAllGroupForTeacher(tx *gorm.DB, teacherId int64, offset int, limit int, sort string) ([]models.Group, error) {
+func (gr *MockGroupRepository) GetAllForTeacher(tx *gorm.DB, teacherId int64, offset int, limit int, sort string) ([]models.Group, error) {
 	var groups []models.Group
 	for _, group := range gr.groups {
 		if group.CreatedBy == teacherId {
@@ -559,12 +559,12 @@ func (gr *MockGroupRepository) GetAllGroupForTeacher(tx *gorm.DB, teacherId int6
 	return groups, nil
 }
 
-func (gr *MockGroupRepository) GetGroupUsers(tx *gorm.DB, groupId int64) ([]models.User, error) {
+func (gr *MockGroupRepository) GetUsers(tx *gorm.DB, groupId int64) ([]models.User, error) {
 	var users []models.User
 	for _, userGroup := range gr.userGroups {
 		for _, ug := range userGroup {
 			if ug.GroupId == groupId {
-				user, err := gr.userRepository.GetUser(tx, ug.UserId)
+				user, err := gr.userRepository.Get(tx, ug.UserId)
 				if err == nil {
 					users = append(users, *user)
 				}
@@ -585,7 +585,7 @@ func (gr *MockGroupRepository) UserBelongsTo(tx *gorm.DB, groupId int64, userId 
 	return false, nil
 }
 
-func (gr *MockGroupRepository) GetGroupTasks(tx *gorm.DB, groupId int64) ([]models.Task, error) {
+func (gr *MockGroupRepository) GetTasks(tx *gorm.DB, groupId int64) ([]models.Task, error) {
 	tasks := make([]models.Task, 0)
 	return tasks, nil
 }
@@ -605,16 +605,16 @@ func NewMockGroupRepository(userRepo *MockUserRepository) *MockGroupRepository {
 type MockUserService struct {
 }
 
-func (us *MockUserService) GetUserByEmail(tx *gorm.DB, email string) (*schemas.User, error) {
+func (us *MockUserService) GetByEmail(tx *gorm.DB, email string) (*schemas.User, error) {
 	panic("implement me")
 }
-func (us *MockUserService) GetAllUsers(tx *gorm.DB, queryParams map[string]interface{}) ([]schemas.User, error) {
+func (us *MockUserService) GetAll(tx *gorm.DB, queryParams map[string]any) ([]schemas.User, error) {
 	panic("implement me")
 }
-func (us *MockUserService) GetUserById(tx *gorm.DB, userId int64) (*schemas.User, error) {
+func (us *MockUserService) Get(tx *gorm.DB, userId int64) (*schemas.User, error) {
 	panic("implement me")
 }
-func (us *MockUserService) EditUser(tx *gorm.DB, currentUser schemas.User, userId int64, updateInfo *schemas.UserEdit) error {
+func (us *MockUserService) Edit(tx *gorm.DB, currentUser schemas.User, userId int64, updateInfo *schemas.UserEdit) error {
 	panic("implement me")
 }
 func (us *MockUserService) ChangeRole(tx *gorm.DB, currentUser schemas.User, userId int64, role types.UserRole) error {

--- a/package/domain/models/submission.go
+++ b/package/domain/models/submission.go
@@ -10,9 +10,12 @@ const (
 )
 
 type Submission struct {
-	Id            int64             `gorm:"primaryKey;autoIncrement"`
-	TaskId        int64             `gorm:"not null; foreignKey:TaskID"`
-	UserId        int64             `gorm:"not null; foreignKey:UserID"`
+	Id     int64 `gorm:"primaryKey;autoIncrement"`
+	TaskId int64 `gorm:"not null; foreignKey:TaskID"`
+	UserId int64 `gorm:"not null; foreignKey:UserID"`
+	// Order represents the submission attempt number for a specific task by a user.
+	// The first submission has Order = 1, the second = 2, and so on.
+	// It helps track the sequence of submissions made by a user for a given task.
 	Order         int64             `gorm:"not null"`
 	LanguageId    int64             `gorm:"not null; foreignKey:LanguageID"`
 	Status        string            `gorm:"type:varchar(50);not null"`

--- a/package/domain/types/user_role.go
+++ b/package/domain/types/user_role.go
@@ -21,7 +21,7 @@ const (
 	UserRoleAdmin   UserRole = "admin"
 )
 
-func (ur *UserRole) Scan(value interface{}) error {
+func (ur *UserRole) Scan(value any) error {
 	valueString, ok := value.(string)
 	if !ok {
 		return fmt.Errorf("UserRole must be a string")

--- a/package/repository/input_output_repository.go
+++ b/package/repository/input_output_repository.go
@@ -6,9 +6,12 @@ import (
 )
 
 type InputOutputRepository interface {
+	// Create creates a new input output record in the database
 	Create(tx *gorm.DB, inputOutput *models.InputOutput) error
-	GetInputOutputId(db *gorm.DB, taskId int64, order int64) (int64, error)
+	// DeleteAll deletes all input output records for given task
 	DeleteAll(tx *gorm.DB, taskId int64) error
+	// GetInputOutputId returns the id of the input output record with the given task id and order
+	GetInputOutputId(db *gorm.DB, taskId int64, order int64) (int64, error)
 }
 
 type inputOutputRepository struct{}

--- a/package/repository/language_repository.go
+++ b/package/repository/language_repository.go
@@ -6,19 +6,26 @@ import (
 )
 
 type LanguageRepository interface {
-	GetLanguages(tx *gorm.DB) ([]models.LanguageConfig, error)
-	GetLanguage(tx *gorm.DB, languageId int64) (*models.LanguageConfig, error)
-	CreateLanguage(tx *gorm.DB, language *models.LanguageConfig) error
-	DeleteLanguage(tx *gorm.DB, languageId int64) error
-	MarkLanguageDisabled(tx *gorm.DB, languageId int64) error
-	MarkLanguageEnabled(tx *gorm.DB, languageId int64) error
-	GetEnabledLanguages(tx *gorm.DB) ([]models.LanguageConfig, error)
+	// Create creates a new language
+	Create(tx *gorm.DB, language *models.LanguageConfig) error
+	// Delete deletes a language
+	Delete(tx *gorm.DB, languageId int64) error
+	// Get returns a language by id
+	Get(tx *gorm.DB, languageId int64) (*models.LanguageConfig, error)
+	// GetAll returns all languages
+	GetAll(tx *gorm.DB) ([]models.LanguageConfig, error)
+	// GetEnabled returns all enabled languages
+	GetEnabled(tx *gorm.DB) ([]models.LanguageConfig, error)
+	// MarkDisabled marks a language as disabled
+	MarkDisabled(tx *gorm.DB, languageId int64) error
+	// MarkEnabled marks a language as enabled
+	MarkEnabled(tx *gorm.DB, languageId int64) error
 }
 
 type languageRepository struct {
 }
 
-func (l *languageRepository) GetLanguages(tx *gorm.DB) ([]models.LanguageConfig, error) {
+func (l *languageRepository) GetAll(tx *gorm.DB) ([]models.LanguageConfig, error) {
 	tasks := []models.LanguageConfig{}
 	err := tx.Model(&models.LanguageConfig{}).Find(&tasks).Error
 	if err != nil {
@@ -27,31 +34,31 @@ func (l *languageRepository) GetLanguages(tx *gorm.DB) ([]models.LanguageConfig,
 	return tasks, nil
 }
 
-func (l *languageRepository) GetLanguage(tx *gorm.DB, languageId int64) (*models.LanguageConfig, error) {
+func (l *languageRepository) Get(tx *gorm.DB, languageId int64) (*models.LanguageConfig, error) {
 	panic("implement me")
 }
 
-func (l *languageRepository) CreateLanguage(tx *gorm.DB, language *models.LanguageConfig) error {
+func (l *languageRepository) Create(tx *gorm.DB, language *models.LanguageConfig) error {
 	err := tx.Model(models.LanguageConfig{}).Create(&language).Error
 	return err
 }
 
-func (l *languageRepository) DeleteLanguage(tx *gorm.DB, languageId int64) error {
+func (l *languageRepository) Delete(tx *gorm.DB, languageId int64) error {
 	err := tx.Model(&models.LanguageConfig{}).Where("id = ?", languageId).Delete(&models.LanguageConfig{}).Error
 	return err
 }
 
-func (l *languageRepository) MarkLanguageDisabled(tx *gorm.DB, languageId int64) error {
+func (l *languageRepository) MarkDisabled(tx *gorm.DB, languageId int64) error {
 	err := tx.Model(&models.LanguageConfig{}).Where("id = ?", languageId).Update("disabled", true).Error
 	return err
 }
 
-func (l *languageRepository) MarkLanguageEnabled(tx *gorm.DB, languageId int64) error {
+func (l *languageRepository) MarkEnabled(tx *gorm.DB, languageId int64) error {
 	err := tx.Model(&models.LanguageConfig{}).Where("id = ?", languageId).Update("disabled", false).Error
 	return err
 }
 
-func (l *languageRepository) GetEnabledLanguages(tx *gorm.DB) ([]models.LanguageConfig, error) {
+func (l *languageRepository) GetEnabled(tx *gorm.DB) ([]models.LanguageConfig, error) {
 	tasks := []models.LanguageConfig{}
 	err := tx.Model(&models.LanguageConfig{}).Where("disabled = ?", false).Find(&tasks).Error
 	if err != nil {

--- a/package/repository/queue_message_repository.go
+++ b/package/repository/queue_message_repository.go
@@ -6,16 +6,18 @@ import (
 )
 
 type QueueMessageRepository interface {
-	// CreateQueueMessage creates a new queue message and returns the message ID
-	CreateQueueMessage(tx *gorm.DB, queueMessage *models.QueueMessage) (string, error)
-	GetQueueMessage(tx *gorm.DB, messageId string) (*models.QueueMessage, error)
-	DeleteQueueMessage(tx *gorm.DB, messageId string) error
+	// Create creates a new queue message and returns the message Id
+	Create(tx *gorm.DB, queueMessage *models.QueueMessage) (string, error)
+	// Delete deletes a queue message by Id
+	Delete(tx *gorm.DB, messageId string) error
+	// Get returns a queue message by Id
+	Get(tx *gorm.DB, messageId string) (*models.QueueMessage, error)
 }
 
 type queueMessageRepository struct {
 }
 
-func (qm *queueMessageRepository) CreateQueueMessage(tx *gorm.DB, queueMessage *models.QueueMessage) (string, error) {
+func (qm *queueMessageRepository) Create(tx *gorm.DB, queueMessage *models.QueueMessage) (string, error) {
 	err := tx.Create(queueMessage).Error
 	if err != nil {
 		return "", err
@@ -23,7 +25,7 @@ func (qm *queueMessageRepository) CreateQueueMessage(tx *gorm.DB, queueMessage *
 	return queueMessage.Id, nil
 }
 
-func (qm *queueMessageRepository) GetQueueMessage(tx *gorm.DB, messageId string) (*models.QueueMessage, error) {
+func (qm *queueMessageRepository) Get(tx *gorm.DB, messageId string) (*models.QueueMessage, error) {
 	queueMessage := &models.QueueMessage{}
 	err := tx.Model(&models.QueueMessage{}).Where("id = ?", messageId).First(queueMessage).Error
 	if err != nil {
@@ -32,7 +34,7 @@ func (qm *queueMessageRepository) GetQueueMessage(tx *gorm.DB, messageId string)
 	return queueMessage, nil
 }
 
-func (qm *queueMessageRepository) DeleteQueueMessage(tx *gorm.DB, messageId string) error {
+func (qm *queueMessageRepository) Delete(tx *gorm.DB, messageId string) error {
 	err := tx.Model(&models.QueueMessage{}).Where("id = ?", messageId).Delete(&models.QueueMessage{}).Error
 	if err != nil {
 		return err

--- a/package/repository/session_repository.go
+++ b/package/repository/session_repository.go
@@ -8,22 +8,25 @@ import (
 )
 
 type SessionRepository interface {
-	CreateSession(tx *gorm.DB, session *models.Session) error
-	GetSession(tx *gorm.DB, sessionId string) (*models.Session, error)
-	GetSessionByUserId(tx *gorm.DB, userId int64) (*models.Session, error)
-	UpdateExpiration(tx *gorm.DB, sessionId string, expires_at time.Time) error
-	DeleteSession(tx *gorm.DB, sessionId string) error
+	// Create creates a new session in the database.
+	Create(tx *gorm.DB, session *models.Session) error
+	// Delete deletes a session from the database.
+	Delete(tx *gorm.DB, sessionId string) error
+	// Get retrieves a session from the database by its Id.
+	Get(tx *gorm.DB, sessionId string) (*models.Session, error)
+	// GetByUserId retrieves a session from the database by the user Id.
+	GetByUserId(tx *gorm.DB, userId int64) (*models.Session, error)
 }
 
 type sessionRepository struct {
 }
 
-func (s *sessionRepository) CreateSession(tx *gorm.DB, session *models.Session) error {
+func (s *sessionRepository) Create(tx *gorm.DB, session *models.Session) error {
 	err := tx.Model(&models.Session{}).Create(session).Error
 	return err
 }
 
-func (s *sessionRepository) GetSession(tx *gorm.DB, sessionId string) (*models.Session, error) {
+func (s *sessionRepository) Get(tx *gorm.DB, sessionId string) (*models.Session, error) {
 	session := &models.Session{}
 	err := tx.Model(&models.Session{}).Where("id = ?", sessionId).Take(session).Error
 	if err != nil {
@@ -32,7 +35,7 @@ func (s *sessionRepository) GetSession(tx *gorm.DB, sessionId string) (*models.S
 	return session, nil
 }
 
-func (s *sessionRepository) GetSessionByUserId(tx *gorm.DB, userId int64) (*models.Session, error) {
+func (s *sessionRepository) GetByUserId(tx *gorm.DB, userId int64) (*models.Session, error) {
 	session := &models.Session{}
 	err := tx.Model(&models.Session{}).Preload("User").Where("user_id = ?", userId).Take(session).Error
 	if err != nil {
@@ -46,7 +49,7 @@ func (s *sessionRepository) UpdateExpiration(tx *gorm.DB, sessionId string, expi
 	return err
 }
 
-func (s *sessionRepository) DeleteSession(tx *gorm.DB, sessionId string) error {
+func (s *sessionRepository) Delete(tx *gorm.DB, sessionId string) error {
 	err := tx.Model(&models.Session{}).Where("id = ?", sessionId).Delete(&models.Session{}).Error
 	return err
 }

--- a/package/repository/submission_result_repository.go
+++ b/package/repository/submission_result_repository.go
@@ -6,13 +6,13 @@ import (
 )
 
 type SubmissionResultRepository interface {
-	CreateSubmissionResult(tx *gorm.DB, solutionResult models.SubmissionResult) (int64, error)
+	// Create creates a new submission result in the database
+	Create(tx *gorm.DB, solutionResult models.SubmissionResult) (int64, error)
 }
 
 type submissionResultRepository struct{}
 
-// Store the result of the solution in the database
-func (usr *submissionResultRepository) CreateSubmissionResult(tx *gorm.DB, submissionResult models.SubmissionResult) (int64, error) {
+func (usr *submissionResultRepository) Create(tx *gorm.DB, submissionResult models.SubmissionResult) (int64, error) {
 	if err := tx.Create(&submissionResult).Error; err != nil {
 		return 0, err
 	}

--- a/package/repository/test_result_repository.go
+++ b/package/repository/test_result_repository.go
@@ -6,12 +6,13 @@ import (
 )
 
 type TestRepository interface {
-	CreateTestResults(tx *gorm.DB, testResult models.TestResult) error
+	// Create creates a new test result in the database
+	Create(tx *gorm.DB, testResult models.TestResult) error
 }
 
 type testResultRepository struct{}
 
-func (tr *testResultRepository) CreateTestResults(tx *gorm.DB, testResult models.TestResult) error {
+func (tr *testResultRepository) Create(tx *gorm.DB, testResult models.TestResult) error {
 	err := tx.Create(&testResult).Error
 	return err
 }

--- a/package/repository/user_repository.go
+++ b/package/repository/user_repository.go
@@ -7,18 +7,22 @@ import (
 )
 
 type UserRepository interface {
-	// CreateUser creates a new user and returns the user ID
-	CreateUser(tx *gorm.DB, user *models.User) (int64, error)
-	GetUser(tx *gorm.DB, userId int64) (*models.User, error)
-	GetUserByEmail(tx *gorm.DB, email string) (*models.User, error)
-	GetAllUsers(tx *gorm.DB, limit, offset int, sort string) ([]models.User, error)
-	EditUser(tx *gorm.DB, user *models.User) error
+	// Create creates a new user and returns the user ID
+	Create(tx *gorm.DB, user *models.User) (int64, error)
+	// Edit updates the user information by setting the new values
+	Edit(tx *gorm.DB, user *models.User) error
+	// GetAll returns all users with pagination and sorting
+	GetAll(tx *gorm.DB, limit, offset int, sort string) ([]models.User, error)
+	// Get returns a user by Id
+	Get(tx *gorm.DB, userId int64) (*models.User, error)
+	//
+	GetByEmail(tx *gorm.DB, email string) (*models.User, error)
 }
 
 type userRepository struct {
 }
 
-func (ur *userRepository) CreateUser(tx *gorm.DB, user *models.User) (int64, error) {
+func (ur *userRepository) Create(tx *gorm.DB, user *models.User) (int64, error) {
 	err := tx.Model(&models.User{}).Create(user).Error
 	if err != nil {
 		return 0, err
@@ -26,7 +30,7 @@ func (ur *userRepository) CreateUser(tx *gorm.DB, user *models.User) (int64, err
 	return user.Id, nil
 }
 
-func (ur *userRepository) GetUser(tx *gorm.DB, userId int64) (*models.User, error) {
+func (ur *userRepository) Get(tx *gorm.DB, userId int64) (*models.User, error) {
 	user := &models.User{}
 	err := tx.Model(&models.User{}).Where("id = ?", userId).Take(user).Error
 	if err != nil {
@@ -35,7 +39,7 @@ func (ur *userRepository) GetUser(tx *gorm.DB, userId int64) (*models.User, erro
 	return user, nil
 }
 
-func (ur *userRepository) GetUserByEmail(tx *gorm.DB, email string) (*models.User, error) {
+func (ur *userRepository) GetByEmail(tx *gorm.DB, email string) (*models.User, error) {
 	user := &models.User{}
 	err := tx.Model(&models.User{}).Where("email = ?", email).First(user).Error
 	if err != nil {
@@ -44,7 +48,7 @@ func (ur *userRepository) GetUserByEmail(tx *gorm.DB, email string) (*models.Use
 	return user, nil
 }
 
-func (ur *userRepository) GetAllUsers(tx *gorm.DB, limit, offset int, sort string) ([]models.User, error) {
+func (ur *userRepository) GetAll(tx *gorm.DB, limit, offset int, sort string) ([]models.User, error) {
 	users := &[]models.User{}
 	tx, err := utils.ApplyPaginationAndSort(tx, limit, offset, sort)
 	if err != nil {
@@ -58,7 +62,7 @@ func (ur *userRepository) GetAllUsers(tx *gorm.DB, limit, offset int, sort strin
 	return *users, nil
 }
 
-func (ur *userRepository) EditUser(tx *gorm.DB, user *models.User) error {
+func (ur *userRepository) Edit(tx *gorm.DB, user *models.User) error {
 	err := tx.Save(user).Error
 	return err
 }

--- a/package/service/auth_service.go
+++ b/package/service/auth_service.go
@@ -39,7 +39,7 @@ type authService struct {
 
 // Login implements Login method of [AuthService] interface
 func (as *authService) Login(tx *gorm.DB, userLogin schemas.UserLoginRequest) (*schemas.Session, error) {
-	user, err := as.userRepository.GetUserByEmail(tx, userLogin.Email)
+	user, err := as.userRepository.GetByEmail(tx, userLogin.Email)
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
 			return nil, errors.ErrUserNotFound
@@ -54,7 +54,7 @@ func (as *authService) Login(tx *gorm.DB, userLogin schemas.UserLoginRequest) (*
 		return nil, errors.ErrInvalidCredentials
 	}
 
-	session, err := as.sessionService.CreateSession(tx, user.Id)
+	session, err := as.sessionService.Create(tx, user.Id)
 	if err != nil {
 		as.logger.Errorf("Error creating session: %v", err.Error())
 		return nil, err
@@ -65,7 +65,7 @@ func (as *authService) Login(tx *gorm.DB, userLogin schemas.UserLoginRequest) (*
 
 // Register implements Register method of [AuthService] interface
 func (as *authService) Register(tx *gorm.DB, userRegister schemas.UserRegisterRequest) (*schemas.Session, error) {
-	user, err := as.userRepository.GetUserByEmail(tx, userRegister.Email)
+	user, err := as.userRepository.GetByEmail(tx, userRegister.Email)
 	if err != nil && err != gorm.ErrRecordNotFound {
 		as.logger.Errorf("Error getting user by email: %v", err.Error())
 		return nil, err
@@ -90,13 +90,13 @@ func (as *authService) Register(tx *gorm.DB, userRegister schemas.UserRegisterRe
 		Role:         types.UserRoleStudent,
 	}
 
-	userId, err := as.userRepository.CreateUser(tx, userModel)
+	userId, err := as.userRepository.Create(tx, userModel)
 	if err != nil {
 		as.logger.Errorf("Error creating user: %v", err.Error())
 		return nil, err
 	}
 
-	session, err := as.sessionService.CreateSession(tx, userId)
+	session, err := as.sessionService.Create(tx, userId)
 	if err != nil {
 		as.logger.Errorf("Error creating session: %v", err.Error())
 		return nil, err

--- a/package/service/auth_service_test.go
+++ b/package/service/auth_service_test.go
@@ -20,7 +20,7 @@ func TestRegister(t *testing.T) {
 	tx := &gorm.DB{}
 
 	t.Run("get user by email when user exists", func(t *testing.T) {
-		ur.CreateUser(tx, &models.User{
+		ur.Create(tx, &models.User{
 			Name:         "name",
 			Surname:      "surname",
 			Email:        "email2@email.com",
@@ -94,7 +94,7 @@ func TestLogin(t *testing.T) {
 			Username:     "username",
 			PasswordHash: "password",
 		}
-		ur.CreateUser(tx, user)
+		ur.Create(tx, user)
 		userLogin := schemas.UserLoginRequest{
 			Email:    user.Email,
 			Password: user.PasswordHash,
@@ -115,7 +115,7 @@ func TestLogin(t *testing.T) {
 			Username:     "username",
 			PasswordHash: string(passwordHash),
 		}
-		ur.CreateUser(tx, user)
+		ur.Create(tx, user)
 		userLogin := schemas.UserLoginRequest{
 			Email:    user.Email,
 			Password: password,

--- a/package/service/session_service_test.go
+++ b/package/service/session_service_test.go
@@ -37,7 +37,7 @@ func newSessionServiceTest() *sessionServiceTest {
 func TestValidateSession(t *testing.T) {
 	sst := newSessionServiceTest()
 	t.Run("Session not found", func(t *testing.T) {
-		validateSession, err := sst.ss.ValidateSession(sst.tx, "test-session-id")
+		validateSession, err := sst.ss.Validate(sst.tx, "test-session-id")
 		assert.ErrorIs(t, err, ErrSessionNotFound)
 		assert.False(t, validateSession.Valid)
 		assert.Equal(t, InvalidUser.Id, validateSession.User.Id)
@@ -51,12 +51,12 @@ func TestValidateSession(t *testing.T) {
 			PasswordHash: "test-password-hash",
 			Role:         types.UserRoleAdmin,
 		}
-		userId, err := sst.ur.CreateUser(sst.tx, user)
+		userId, err := sst.ur.Create(sst.tx, user)
 		assert.NoError(t, err)
-		session, err := sst.ss.CreateSession(sst.tx, userId)
+		session, err := sst.ss.Create(sst.tx, userId)
 		assert.NoError(t, err)
 		assert.NotNil(t, session)
-		validateSession, err := sst.ss.ValidateSession(sst.tx, session.Id)
+		validateSession, err := sst.ss.Validate(sst.tx, session.Id)
 		assert.NoError(t, err)
 		assert.True(t, validateSession.Valid)
 		assert.Equal(t, userId, validateSession.User.Id)
@@ -75,16 +75,16 @@ func TestValidateSession(t *testing.T) {
 			PasswordHash: "test-password-hash",
 			Role:         types.UserRoleAdmin,
 		}
-		userId, err := sst.ur.CreateUser(sst.tx, user)
+		userId, err := sst.ur.Create(sst.tx, user)
 		assert.NoError(t, err)
 		session := &models.Session{
 			Id:        "test-session-id",
 			UserId:    userId,
 			ExpiresAt: time.Now().Add(-time.Hour),
 		}
-		err = sst.sr.CreateSession(sst.tx, session)
+		err = sst.sr.Create(sst.tx, session)
 		assert.NoError(t, err)
-		validateSession, err := sst.ss.ValidateSession(sst.tx, session.Id)
+		validateSession, err := sst.ss.Validate(sst.tx, session.Id)
 		assert.ErrorIs(t, err, ErrSessionExpired)
 		assert.False(t, validateSession.Valid)
 		assert.Equal(t, InvalidUser.Id, validateSession.User.Id)
@@ -92,7 +92,7 @@ func TestValidateSession(t *testing.T) {
 
 	t.Run("Unexpected error during get session", func(t *testing.T) {
 		sst.sr.FailNext()
-		validateSession, err := sst.ss.ValidateSession(sst.tx, "test-session-id")
+		validateSession, err := sst.ss.Validate(sst.tx, "test-session-id")
 		assert.Error(t, err)
 		assert.False(t, validateSession.Valid)
 		assert.Equal(t, InvalidUser.Id, validateSession.User.Id)
@@ -107,13 +107,13 @@ func TestValidateSession(t *testing.T) {
 			PasswordHash: "test-password-hash",
 			Role:         types.UserRoleAdmin,
 		}
-		userId, err := sst.ur.CreateUser(sst.tx, user)
+		userId, err := sst.ur.Create(sst.tx, user)
 		assert.NoError(t, err)
-		session, err := sst.ss.CreateSession(sst.tx, userId)
+		session, err := sst.ss.Create(sst.tx, userId)
 		assert.NoError(t, err)
 		assert.NotNil(t, session)
 		sst.ur.FailNext()
-		validateSession, err := sst.ss.ValidateSession(sst.tx, session.Id)
+		validateSession, err := sst.ss.Validate(sst.tx, session.Id)
 		assert.Error(t, err)
 		assert.False(t, validateSession.Valid)
 		assert.Equal(t, InvalidUser.Id, validateSession.User.Id)
@@ -125,9 +125,9 @@ func TestValidateSession(t *testing.T) {
 			UserId:    -1234,
 			ExpiresAt: time.Now().Add(time.Hour),
 		}
-		err := sst.sr.CreateSession(sst.tx, session)
+		err := sst.sr.Create(sst.tx, session)
 		assert.NoError(t, err)
-		validateSession, err := sst.ss.ValidateSession(sst.tx, session.Id)
+		validateSession, err := sst.ss.Validate(sst.tx, session.Id)
 		assert.Error(t, err)
 		assert.False(t, validateSession.Valid)
 		assert.Equal(t, InvalidUser.Id, validateSession.User.Id)
@@ -137,11 +137,11 @@ func TestValidateSession(t *testing.T) {
 func TestInvalidateSession(t *testing.T) {
 	sst := newSessionServiceTest()
 	t.Run("Session not found", func(t *testing.T) {
-		err := sst.ss.InvalidateSession(sst.tx, "test-session-id")
+		err := sst.ss.Invalidate(sst.tx, "test-session-id")
 		assert.NoError(t, err)
 	})
 	t.Run("Session found", func(t *testing.T) {
-		userId, err := sst.ur.CreateUser(sst.tx, &models.User{
+		userId, err := sst.ur.Create(sst.tx, &models.User{
 			Name:         "test-name",
 			Surname:      "test-surname",
 			Email:        "test-email",
@@ -150,12 +150,12 @@ func TestInvalidateSession(t *testing.T) {
 			Role:         "admin",
 		})
 		assert.NoError(t, err)
-		session, err := sst.ss.CreateSession(sst.tx, userId)
+		session, err := sst.ss.Create(sst.tx, userId)
 		assert.NoError(t, err)
 		assert.NotNil(t, session)
-		err = sst.ss.InvalidateSession(sst.tx, session.Id)
+		err = sst.ss.Invalidate(sst.tx, session.Id)
 		assert.NoError(t, err)
-		validateSession, err := sst.ss.ValidateSession(sst.tx, session.Id)
+		validateSession, err := sst.ss.Validate(sst.tx, session.Id)
 		assert.ErrorIs(t, err, ErrSessionNotFound)
 		assert.False(t, validateSession.Valid)
 		assert.Equal(t, InvalidUser.Id, validateSession.User.Id)
@@ -167,21 +167,21 @@ func TestCreateSession(t *testing.T) {
 	sst := newSessionServiceTest()
 
 	t.Run("User not found", func(t *testing.T) {
-		session, err := sst.ss.CreateSession(sst.tx, 0)
+		session, err := sst.ss.Create(sst.tx, 0)
 		assert.ErrorIs(t, err, errors.ErrNotFound)
 		assert.Nil(t, session)
 	})
 
 	t.Run("Unexpected error during get user", func(t *testing.T) {
 		sst.ur.FailNext()
-		session, err := sst.ss.CreateSession(sst.tx, -1)
+		session, err := sst.ss.Create(sst.tx, -1)
 		assert.Error(t, err)
 		assert.Nil(t, session)
 	})
 
 	t.Run("Unexpected error during get session", func(t *testing.T) {
 		sst.sr.FailNext()
-		userId, err := sst.ur.CreateUser(sst.tx, &models.User{
+		userId, err := sst.ur.Create(sst.tx, &models.User{
 			Name:         "test-name",
 			Surname:      "test-surname",
 			Email:        "test-email",
@@ -190,7 +190,7 @@ func TestCreateSession(t *testing.T) {
 			Role:         types.UserRoleAdmin,
 		})
 		assert.NoError(t, err)
-		session, err := sst.ss.CreateSession(sst.tx, userId)
+		session, err := sst.ss.Create(sst.tx, userId)
 		if !assert.NotEqual(t, err, errors.ErrNotFound) {
 			t.Fatalf("Invalid error, exp!=%q, got=%q", errors.ErrNotFound, err)
 		}
@@ -199,7 +199,7 @@ func TestCreateSession(t *testing.T) {
 	})
 
 	t.Run("Session expired", func(t *testing.T) {
-		userId, err := sst.ur.CreateUser(sst.tx, &models.User{
+		userId, err := sst.ur.Create(sst.tx, &models.User{
 			Name:         "test-name",
 			Surname:      "test-surname",
 			Email:        "test-email",
@@ -213,15 +213,15 @@ func TestCreateSession(t *testing.T) {
 			UserId:    userId,
 			ExpiresAt: time.Now().Add(-time.Hour),
 		}
-		err = sst.sr.CreateSession(sst.tx, expSession)
+		err = sst.sr.Create(sst.tx, expSession)
 		assert.NoError(t, err)
-		session, err := sst.ss.CreateSession(sst.tx, userId)
+		session, err := sst.ss.Create(sst.tx, userId)
 		assert.NoError(t, err)
 		assert.NotNil(t, session)
 	})
 
 	t.Run("Session exists", func(t *testing.T) {
-		userId, err := sst.ur.CreateUser(sst.tx, &models.User{
+		userId, err := sst.ur.Create(sst.tx, &models.User{
 			Name:         "test-name",
 			Surname:      "test-surname",
 			Email:        "test-email",
@@ -235,9 +235,9 @@ func TestCreateSession(t *testing.T) {
 			UserId:    userId,
 			ExpiresAt: time.Now().Add(+time.Hour),
 		}
-		err = sst.sr.CreateSession(sst.tx, existingSession)
+		err = sst.sr.Create(sst.tx, existingSession)
 		assert.NoError(t, err)
-		session, err := sst.ss.CreateSession(sst.tx, userId)
+		session, err := sst.ss.Create(sst.tx, userId)
 		assert.NoError(t, err)
 		assert.NotNil(t, session)
 		assert.IsType(t, &schemas.Session{}, session)

--- a/package/utils/utils.go
+++ b/package/utils/utils.go
@@ -109,7 +109,7 @@ func GetSort(str string) string {
 // ValidateStruct validates that every field of a given struct is initialized
 //
 // Source: https://medium.com/@anajankow/fast-check-if-all-struct-fields-are-set-in-golang-bba1917213d2
-func ValidateStruct(s interface{}) (err error) {
+func ValidateStruct(s any) (err error) {
 	// first make sure that the input is a struct
 	// having any other type, especially a pointer to a struct,
 	// might result in panic

--- a/package/utils/utils_test.go
+++ b/package/utils/utils_test.go
@@ -14,7 +14,7 @@ type Data struct {
 	ptr          *string
 	structMember Impl
 	ifMember     Interfc
-	mapMember    map[string]interface{}
+	mapMember    map[string]any
 	sliceMember  []string
 }
 
@@ -57,7 +57,7 @@ func TestValidateStructEmpty(t *testing.T) {
 
 			ifMember: Impl{},
 
-			mapMember:   make(map[string]interface{}),
+			mapMember:   make(map[string]any),
 			sliceMember: make([]string, 0),
 		}
 


### PR DESCRIPTION
This pull request includes several changes to the codebase, primarily focusing on updating variable names, adding new functionality to the group routes, and improving consistency in the code. The most important changes include the addition of new fields and methods, renaming of variables for consistency, and updates to the group and session services.

### Addition of new functionality:
* [`internal/api/http/routes/group.go`](diffhunk://#diff-09e6d96f05afd29e160f8b043a3c486f4ba678aab12bdf7709299a3bfbbc087dR309-R377): Added `DeleteUsersFromGroup` and `GetGroupTasks` methods to `GroupRouteImpl`. [[1]](diffhunk://#diff-09e6d96f05afd29e160f8b043a3c486f4ba678aab12bdf7709299a3bfbbc087dR309-R377) [[2]](diffhunk://#diff-09e6d96f05afd29e160f8b043a3c486f4ba678aab12bdf7709299a3bfbbc087dL348-R418) [[3]](diffhunk://#diff-09e6d96f05afd29e160f8b043a3c486f4ba678aab12bdf7709299a3bfbbc087dR501-R510)
* [`internal/api/http/routes/group.go`](diffhunk://#diff-09e6d96f05afd29e160f8b043a3c486f4ba678aab12bdf7709299a3bfbbc087dR501-R510): Updated `RegisterGroupRoutes` to handle new routes for deleting users from a group and getting group tasks.

### Updates to group and session services:
* [`internal/api/http/routes/group.go`](diffhunk://#diff-09e6d96f05afd29e160f8b043a3c486f4ba678aab12bdf7709299a3bfbbc087dL70-R72): Renamed service methods to match new naming conventions (e.g., `CreateGroup` to `Create`, `GetGroup` to `Get`). [[1]](diffhunk://#diff-09e6d96f05afd29e160f8b043a3c486f4ba678aab12bdf7709299a3bfbbc087dL70-R72) [[2]](diffhunk://#diff-09e6d96f05afd29e160f8b043a3c486f4ba678aab12bdf7709299a3bfbbc087dL123-R125) [[3]](diffhunk://#diff-09e6d96f05afd29e160f8b043a3c486f4ba678aab12bdf7709299a3bfbbc087dL295-R296)
* [`internal/api/http/routes/session.go`](diffhunk://#diff-30dd7d1948293bdf8fb2a9ba39bbf063d649991dc24fd9f88c54308114239451L47-R47): Updated session service method names for consistency (e.g., `CreateSession` to `Create`, `ValidateSession` to `Validate`). [[1]](diffhunk://#diff-30dd7d1948293bdf8fb2a9ba39bbf063d649991dc24fd9f88c54308114239451L47-R47) [[2]](diffhunk://#diff-30dd7d1948293bdf8fb2a9ba39bbf063d649991dc24fd9f88c54308114239451L82-R82) [[3]](diffhunk://#diff-30dd7d1948293bdf8fb2a9ba39bbf063d649991dc24fd9f88c54308114239451L142-R142)

### General code improvements:
* [`internal/api/http/httputils/routes_utils.go`](diffhunk://#diff-e4d942ab76dfaa095b34989acd473f47b00705866027d3c0bc704875381b8f3fL58-R59): Replaced `interface{}` with `any` in function signatures for better type clarity. [[1]](diffhunk://#diff-e4d942ab76dfaa095b34989acd473f47b00705866027d3c0bc704875381b8f3fL58-R59) [[2]](diffhunk://#diff-e4d942ab76dfaa095b34989acd473f47b00705866027d3c0bc704875381b8f3fL128-R128)
* [`internal/api/http/routes/auth_test.go`](diffhunk://#diff-f23cdec5e9aea71252d27fae189ac18fea53324844a178af3306f4da74825b62L49-R49): Updated test cases to use `any` instead of `interface{}` and added `ConfirmPassword` field. [[1]](diffhunk://#diff-f23cdec5e9aea71252d27fae189ac18fea53324844a178af3306f4da74825b62L49-R49) [[2]](diffhunk://#diff-f23cdec5e9aea71252d27fae189ac18fea53324844a178af3306f4da74825b62L234-R235) [[3]](diffhunk://#diff-f23cdec5e9aea71252d27fae189ac18fea53324844a178af3306f4da74825b62L252-R253) [[4]](diffhunk://#diff-f23cdec5e9aea71252d27fae189ac18fea53324844a178af3306f4da74825b62R265-R273) [[5]](diffhunk://#diff-f23cdec5e9aea71252d27fae189ac18fea53324844a178af3306f4da74825b62R282-R289)

These changes aim to improve the consistency and functionality of the codebase, making it easier to maintain and extend in the future.