### PR TITLE
feat: get, put task limits

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -64,7 +64,6 @@ linters:
     - goconst # finds repeated strings that could be replaced by a constant
     - gocritic # provides diagnostics that check for bugs, performance and style issues
     - gocyclo # computes and checks the cyclomatic complexity of functions
-    - godot # checks if comments end in a period
     - gomoddirectives # manages the use of 'replace', 'retract', and 'excludes' directives in go.mod
     - goprintffuncname # checks that printf-like functions are named with f at the end
     # - gosec # inspects source code for security problems # TODO: enable and fix this

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1376,6 +1376,107 @@ const docTemplate = `{
                 }
             }
         },
+        "/task/{id}/limits": {
+            "get": {
+                "description": "Gets task limits by task ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "task"
+                ],
+                "summary": "Gets task limits",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Task ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/APIResponse-string"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/APIError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/APIError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/APIError"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "Updates task limits by task ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "task"
+                ],
+                "summary": "Updates task limits",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Task ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Task limits",
+                        "name": "limits",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/PutInputOutputRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/APIResponse-string"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/APIError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/APIError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/APIError"
+                        }
+                    }
+                }
+            }
+        },
         "/task/{id}/unassign/groups": {
             "delete": {
                 "description": "Unassigns a task from groups by task ID and group IDs",
@@ -2020,6 +2121,31 @@ const docTemplate = `{
                 }
             }
         },
+        "PutInputOutput": {
+            "type": "object",
+            "properties": {
+                "memory_limit": {
+                    "type": "integer"
+                },
+                "order": {
+                    "type": "integer"
+                },
+                "time_limit": {
+                    "type": "integer"
+                }
+            }
+        },
+        "PutInputOutputRequest": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/PutInputOutput"
+                    }
+                }
+            }
+        },
         "Session": {
             "type": "object",
             "properties": {
@@ -2349,7 +2475,7 @@ const docTemplate = `{
     }
 }`
 
-// SwaggerInfo holds exported Swagger Info so clients can modify it.
+// SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
 	Version:          "1.0.0",
 	Host:             "",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -146,6 +146,22 @@ definitions:
       version:
         type: string
     type: object
+  PutInputOutput:
+    properties:
+      memory_limit:
+        type: integer
+      order:
+        type: integer
+      time_limit:
+        type: integer
+    type: object
+  PutInputOutputRequest:
+    properties:
+      limits:
+        items:
+          $ref: '#/definitions/PutInputOutput'
+        type: array
+    type: object
   Session:
     properties:
       expires_at:
@@ -1238,6 +1254,73 @@ paths:
           schema:
             $ref: '#/definitions/APIError'
       summary: Assign a task to users
+      tags:
+      - task
+  /task/{id}/limits:
+    get:
+      description: Gets task limits by task ID
+      parameters:
+      - description: Task ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/APIResponse-string'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/APIError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/APIError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/APIError'
+      summary: Gets task limits
+      tags:
+      - task
+    put:
+      description: Updates task limits by task ID
+      parameters:
+      - description: Task ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      - description: Task limits
+        in: body
+        name: limits
+        required: true
+        schema:
+          $ref: '#/definitions/PutInputOutputRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/APIResponse-string'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/APIError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/APIError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/APIError'
+      summary: Updates task limits
       tags:
       - task
   /task/{id}/unassign/groups:

--- a/internal/api/http/routes/task.go
+++ b/internal/api/http/routes/task.go
@@ -21,7 +21,7 @@ type TaskRoute interface {
 	AssignTaskToUsers(w http.ResponseWriter, r *http.Request)
 	DeleteTask(w http.ResponseWriter, r *http.Request)
 	EditTask(w http.ResponseWriter, r *http.Request)
-	GetAllAssingedTasks(w http.ResponseWriter, r *http.Request)
+	GetAllAssignedTasks(w http.ResponseWriter, r *http.Request)
 	GetAllCreatedTasks(w http.ResponseWriter, r *http.Request)
 	GetAllForGroup(w http.ResponseWriter, r *http.Request)
 	GetAllTasks(w http.ResponseWriter, r *http.Request)
@@ -50,7 +50,7 @@ type groupsRequest struct {
 	GroupIDs []int64 `json:"groupIDs"`
 }
 
-func (tr *taskRoute) GetAllAssingedTasks(w http.ResponseWriter, r *http.Request) {
+func (tr *taskRoute) GetAllAssignedTasks(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		httputils.ReturnError(w, http.StatusMethodNotAllowed, "Method not allowed")
 		return
@@ -915,6 +915,6 @@ func RegisterTaskRoutes(mux *http.ServeMux, route TaskRoute) {
 		}
 	})
 	// mux.HandleFunc("/group/{id}", route.GetAllForGroup)
-	mux.HandleFunc("/assigned", route.GetAllAssingedTasks)
+	mux.HandleFunc("/assigned", route.GetAllAssignedTasks)
 	mux.HandleFunc("/created", route.GetAllCreatedTasks)
 }

--- a/internal/api/http/routes/task.go
+++ b/internal/api/http/routes/task.go
@@ -26,6 +26,8 @@ type TaskRoute interface {
 	GetAllForGroup(w http.ResponseWriter, r *http.Request)
 	GetAllTasks(w http.ResponseWriter, r *http.Request)
 	GetTask(w http.ResponseWriter, r *http.Request)
+	GetLimits(w http.ResponseWriter, r *http.Request)
+	PutLimits(w http.ResponseWriter, r *http.Request)
 	UnAssignTaskFromGroups(w http.ResponseWriter, r *http.Request)
 	UnAssignTaskFromUsers(w http.ResponseWriter, r *http.Request)
 	UploadTask(w http.ResponseWriter, r *http.Request)
@@ -33,7 +35,7 @@ type TaskRoute interface {
 
 const taskBodyLimit = 50 << 20
 
-type TaskRouteImpl struct {
+type taskRoute struct {
 	fileStorageURL string
 
 	// Service that handles task-related operations
@@ -48,7 +50,7 @@ type groupsRequest struct {
 	GroupIDs []int64 `json:"groupIDs"`
 }
 
-func (tr *TaskRouteImpl) GetAllAssingedTasks(w http.ResponseWriter, r *http.Request) {
+func (tr *taskRoute) GetAllAssingedTasks(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		httputils.ReturnError(w, http.StatusMethodNotAllowed, "Method not allowed")
 		return
@@ -79,7 +81,7 @@ func (tr *TaskRouteImpl) GetAllAssingedTasks(w http.ResponseWriter, r *http.Requ
 	httputils.ReturnSuccess(w, http.StatusOK, task)
 }
 
-func (tr *TaskRouteImpl) GetAllCreatedTasks(w http.ResponseWriter, r *http.Request) {
+func (tr *taskRoute) GetAllCreatedTasks(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		httputils.ReturnError(w, http.StatusMethodNotAllowed, "Method not allowed")
 		return
@@ -122,7 +124,7 @@ func (tr *TaskRouteImpl) GetAllCreatedTasks(w http.ResponseWriter, r *http.Reque
 //	@Failure		500	{object}	httputils.APIError
 //	@Success		200	{object}	httputils.APIResponse[[]schemas.Task]
 //	@Router			/task/ [get]
-func (tr *TaskRouteImpl) GetAllTasks(w http.ResponseWriter, r *http.Request) {
+func (tr *taskRoute) GetAllTasks(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		httputils.ReturnError(w, http.StatusMethodNotAllowed, "Method not allowed")
 		return
@@ -168,7 +170,7 @@ func (tr *TaskRouteImpl) GetAllTasks(w http.ResponseWriter, r *http.Request) {
 //	@Failure		500	{object}	httputils.APIError
 //	@Success		200	{object}	httputils.APIResponse[schemas.TaskDetailed]
 //	@Router			/task/{id} [get]
-func (tr *TaskRouteImpl) GetTask(w http.ResponseWriter, r *http.Request) {
+func (tr *taskRoute) GetTask(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		httputils.ReturnError(w, http.StatusMethodNotAllowed, "Method not allowed")
 		return
@@ -221,7 +223,7 @@ func (tr *TaskRouteImpl) GetTask(w http.ResponseWriter, r *http.Request) {
 //	@Failure		500	{object}	httputils.APIError
 //	@Success		200	{object}	httputils.APIResponse[[]schemas.Task]
 //	@Router			/task/group/{id} [get]
-func (tr *TaskRouteImpl) GetAllForGroup(w http.ResponseWriter, r *http.Request) {
+func (tr *taskRoute) GetAllForGroup(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		httputils.ReturnError(w, http.StatusMethodNotAllowed, "Method not allowed")
 		return
@@ -283,7 +285,7 @@ func (tr *TaskRouteImpl) GetAllForGroup(w http.ResponseWriter, r *http.Request) 
 //	@Failure		500			{object}	httputils.APIError
 //	@Success		200			{object}	httputils.APIResponse[schemas.TaskCreateResponse]
 //	@Router			/task/ [post]
-func (tr *TaskRouteImpl) UploadTask(w http.ResponseWriter, r *http.Request) {
+func (tr *taskRoute) UploadTask(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		httputils.ReturnError(w, http.StatusMethodNotAllowed, "Method not allowed")
 		return
@@ -376,7 +378,7 @@ func (tr *TaskRouteImpl) UploadTask(w http.ResponseWriter, r *http.Request) {
 //	@Failure		500		{object}	httputils.APIError
 //	@Success		200		{object}	httputils.APIResponse[string]
 //	@Router			/task/{id} [patch]
-func (tr *TaskRouteImpl) EditTask(w http.ResponseWriter, r *http.Request) {
+func (tr *taskRoute) EditTask(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPatch {
 		httputils.ReturnError(w, http.StatusMethodNotAllowed, "Method not allowed")
 		return
@@ -468,7 +470,7 @@ func (tr *TaskRouteImpl) EditTask(w http.ResponseWriter, r *http.Request) {
 //	@Failure		500	{object}	httputils.APIError
 //	@Success		200	{object}	httputils.APIResponse[string]
 //	@Router			/task/{id} [delete]
-func (tr *TaskRouteImpl) DeleteTask(w http.ResponseWriter, r *http.Request) {
+func (tr *taskRoute) DeleteTask(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodDelete {
 		httputils.ReturnError(w, http.StatusMethodNotAllowed, "Method not allowed")
 		return
@@ -522,7 +524,7 @@ func (tr *TaskRouteImpl) DeleteTask(w http.ResponseWriter, r *http.Request) {
 //	@Failure		500		{object}	httputils.APIError
 //	@Success		200		{object}	httputils.APIResponse[string]
 //	@Router			/task/{id}/assign/users [post]
-func (tr *TaskRouteImpl) AssignTaskToUsers(w http.ResponseWriter, r *http.Request) {
+func (tr *taskRoute) AssignTaskToUsers(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		httputils.ReturnError(w, http.StatusMethodNotAllowed, "Method not allowed")
 		return
@@ -584,7 +586,7 @@ func (tr *TaskRouteImpl) AssignTaskToUsers(w http.ResponseWriter, r *http.Reques
 //	@Failure		500			{object}	httputils.APIError
 //	@Success		200			{object}	httputils.APIResponse[string]
 //	@Router			/task/{id}/assign/groups [post]
-func (tr *TaskRouteImpl) AssignTaskToGroups(w http.ResponseWriter, r *http.Request) {
+func (tr *taskRoute) AssignTaskToGroups(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		httputils.ReturnError(w, http.StatusMethodNotAllowed, "Method not allowed")
 		return
@@ -646,7 +648,7 @@ func (tr *TaskRouteImpl) AssignTaskToGroups(w http.ResponseWriter, r *http.Reque
 //	@Failure		500		{object}	httputils.APIError
 //	@Success		200		{object}	httputils.APIResponse[string]
 //	@Router			/task/{id}/unassign/users [delete]
-func (tr *TaskRouteImpl) UnAssignTaskFromUsers(w http.ResponseWriter, r *http.Request) {
+func (tr *taskRoute) UnAssignTaskFromUsers(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodDelete {
 		httputils.ReturnError(w, http.StatusMethodNotAllowed, "Method not allowed")
 		return
@@ -708,7 +710,7 @@ func (tr *TaskRouteImpl) UnAssignTaskFromUsers(w http.ResponseWriter, r *http.Re
 //	@Failure		500			{object}	httputils.APIError
 //	@Success		200			{object}	httputils.APIResponse[string]
 //	@Router			/task/{id}/unassign/groups [delete]
-func (tr *TaskRouteImpl) UnAssignTaskFromGroups(w http.ResponseWriter, r *http.Request) {
+func (tr *taskRoute) UnAssignTaskFromGroups(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodDelete {
 		httputils.ReturnError(w, http.StatusMethodNotAllowed, "Method not allowed")
 		return
@@ -756,8 +758,112 @@ func (tr *TaskRouteImpl) UnAssignTaskFromGroups(w http.ResponseWriter, r *http.R
 	httputils.ReturnSuccess(w, http.StatusOK, "Task unassigned successfully")
 }
 
+// GetLimits godoc
+//
+// @Tags task
+// @Summary		Gets task limits
+// @Description	Gets task limits by task ID
+// @Produce		json
+// @Param			id			path		int		true	"Task ID"
+// @Failure		400			{object}	httputils.APIError
+// @Failure		404			{object}	httputils.APIError
+// @Failure		500			{object}	httputils.APIError
+// @Success		200			{object}	httputils.APIResponse[string]
+// @Router			/task/{id}/limits [get]
+func (tr *taskRoute) GetLimits(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		httputils.ReturnError(w, http.StatusMethodNotAllowed, "Method not allowed")
+		return
+	}
+
+	taskIDStr := r.PathValue("id")
+	if taskIDStr == "" {
+		httputils.ReturnError(w, http.StatusBadRequest, "Task ID is required.")
+		return
+	}
+	taskID, err := strconv.ParseInt(taskIDStr, 10, 64)
+	if err != nil {
+		httputils.ReturnError(w, http.StatusBadRequest, "Invalid task ID.")
+		return
+	}
+
+	db := r.Context().Value(httputils.DatabaseKey).(database.Database)
+	tx, err := db.BeginTransaction()
+	if err != nil {
+		httputils.ReturnError(w, http.StatusInternalServerError, "Transaction was not started by middleware. "+err.Error())
+		return
+	}
+
+	currentUser := r.Context().Value(httputils.UserKey).(schemas.User)
+
+	limits, err := tr.taskService.GetLimits(tx, currentUser, taskID)
+	if err != nil {
+		// TODO: more verbose error handling
+		httputils.ReturnError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	httputils.ReturnSuccess(w, http.StatusOK, limits)
+}
+
+// PutLimits godoc
+//
+// @Tags task
+// @Summary		Updates task limits
+// @Description	Updates task limits by task ID
+// @Produce		json
+// @Param			id			path		int		true	"Task ID"
+// @Param			limits		body		schemas.PutInputOutputRequest	true	"Task limits"
+// @Failure		400			{object}	httputils.APIError
+// @Failure		404			{object}	httputils.APIError
+// @Failure		500			{object}	httputils.APIError
+// @Success		200			{object}	httputils.APIResponse[string]
+// @Router			/task/{id}/limits [put]
+func (tr *taskRoute) PutLimits(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPut {
+		httputils.ReturnError(w, http.StatusMethodNotAllowed, "Method not allowed")
+		return
+	}
+
+	taskIDStr := r.PathValue("id")
+	if taskIDStr == "" {
+		httputils.ReturnError(w, http.StatusBadRequest, "Task ID is required.")
+		return
+	}
+	taskID, err := strconv.ParseInt(taskIDStr, 10, 64)
+	if err != nil {
+		httputils.ReturnError(w, http.StatusBadRequest, "Invalid task ID.")
+		return
+	}
+
+	db := r.Context().Value(httputils.DatabaseKey).(database.Database)
+	tx, err := db.BeginTransaction()
+	if err != nil {
+		httputils.ReturnError(w, http.StatusInternalServerError, "Transaction was not started by middleware. "+err.Error())
+		return
+	}
+
+	currentUser := r.Context().Value(httputils.UserKey).(schemas.User)
+
+	request := schemas.PutInputOutputRequest{}
+	err = httputils.ShouldBindJSON(r.Body, &request)
+	if err != nil {
+		httputils.ReturnError(w, http.StatusBadRequest, "Invalid request body. "+err.Error())
+		return
+	}
+
+	err = tr.taskService.PutLimits(tx, currentUser, taskID, request)
+	if err != nil {
+		// TODO: more verbose error handling
+		httputils.ReturnError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	httputils.ReturnSuccess(w, http.StatusOK, nil)
+}
+
 func NewTaskRoute(fileStorageURL string, taskService service.TaskService) TaskRoute {
-	route := &TaskRouteImpl{fileStorageURL: fileStorageURL, taskService: taskService}
+	route := &taskRoute{fileStorageURL: fileStorageURL, taskService: taskService}
 
 	err := utils.ValidateStruct(*route)
 	if err != nil {
@@ -798,7 +904,17 @@ func RegisterTaskRoutes(mux *http.ServeMux, route TaskRoute) {
 	mux.HandleFunc("/{id}/assign/groups", route.AssignTaskToGroups)
 	mux.HandleFunc("/{id}/unassign/users", route.UnAssignTaskFromUsers)
 	mux.HandleFunc("/{id}/unassign/groups", route.UnAssignTaskFromGroups)
-	mux.HandleFunc("/group/{id}", route.GetAllForGroup)
+	mux.HandleFunc("/{id}/limits", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			route.GetLimits(w, r)
+		case http.MethodPut:
+			route.PutLimits(w, r)
+		default:
+			httputils.ReturnError(w, http.StatusMethodNotAllowed, "Method not allowed")
+		}
+	})
+	// mux.HandleFunc("/group/{id}", route.GetAllForGroup)
 	mux.HandleFunc("/assigned", route.GetAllAssingedTasks)
 	mux.HandleFunc("/created", route.GetAllCreatedTasks)
 }

--- a/package/domain/schemas/input_output.go
+++ b/package/domain/schemas/input_output.go
@@ -1,9 +1,19 @@
 package schemas
 
 type InputOutput struct {
-	ID          int64   `json:"-"`
-	TaskID      int64   `json:"task_id"`
-	Order       int     `json:"order"`
-	TimeLimit   float64 `json:"time_limit"`
-	MemoryLimit float64 `json:"memory_limit"`
+	ID          int64 `json:"-"`
+	TaskID      int64 `json:"-"`
+	Order       int   `json:"order"`
+	TimeLimit   int64 `json:"time_limit"`
+	MemoryLimit int64 `json:"memory_limit"`
+}
+
+type PutInputOutputRequest struct {
+	Limits []PutInputOutput `json:"limits"`
+}
+
+type PutInputOutput struct {
+	Order       int   `json:"order" validate:"gt=0"`
+	TimeLimit   int64 `json:"time_limit" validate:"gt=0"`
+	MemoryLimit int64 `json:"memory_limit" validate:"gt=0"`
 }

--- a/package/domain/schemas/queue.go
+++ b/package/domain/schemas/queue.go
@@ -37,7 +37,7 @@ type StatusResponsePayload struct {
 }
 
 type QueueTestResult struct {
-	Order        int64  `json:"Order"`
+	Order        int    `json:"Order"`
 	Passed       bool   `json:"Passed"`
 	ErrorMessage string `json:"ErrorMessage"`
 }

--- a/package/repository/input_output_repository.go
+++ b/package/repository/input_output_repository.go
@@ -11,7 +11,13 @@ type InputOutputRepository interface {
 	// DeleteAll deletes all input output records for given task
 	DeleteAll(tx *gorm.DB, taskID int64) error
 	// GetInputOutputID returns the ID of the input output record with the given task ID and order
-	GetInputOutputID(db *gorm.DB, taskID int64, order int64) (int64, error)
+	GetInputOutputID(db *gorm.DB, taskID int64, order int) (int64, error)
+	// GetByTask returns all input/output for given task
+	GetByTask(db *gorm.DB, taskID int64) ([]models.InputOutput, error)
+	// Get returns input/ouput with given ID
+	Get(tx *gorm.DB, ioID int64) (*models.InputOutput, error)
+	// Put updates input/output with given ID
+	Put(tx *gorm.DB, inputOutput *models.InputOutput) error
 }
 
 type inputOutputRepository struct{}
@@ -21,7 +27,7 @@ func (i *inputOutputRepository) Create(tx *gorm.DB, inputOutput *models.InputOut
 	return err
 }
 
-func (i *inputOutputRepository) GetInputOutputID(tx *gorm.DB, taskID int64, order int64) (int64, error) {
+func (i *inputOutputRepository) GetInputOutputID(tx *gorm.DB, taskID int64, order int) (int64, error) {
 	var inputOutputID int64
 	err := tx.Table("input_outputs").Select("id").Where(
 		`task_id = ? AND "order" = ?`,
@@ -33,6 +39,31 @@ func (i *inputOutputRepository) GetInputOutputID(tx *gorm.DB, taskID int64, orde
 
 func (i *inputOutputRepository) DeleteAll(tx *gorm.DB, taskID int64) error {
 	err := tx.Where("task_id = ?", taskID).Delete(&models.InputOutput{}).Error
+	return err
+}
+
+func (i *inputOutputRepository) GetByTask(tx *gorm.DB, taskID int64) ([]models.InputOutput, error) {
+	inputOutput := []models.InputOutput{}
+	err := tx.Model(&models.InputOutput{}).Where("task_id = ?", taskID).Find(&inputOutput).Error
+	if err != nil {
+		return nil, err
+	}
+
+	return inputOutput, nil
+}
+
+func (i *inputOutputRepository) Get(tx *gorm.DB, ioID int64) (*models.InputOutput, error) {
+	inputOutput := &models.InputOutput{}
+	err := tx.Model(&models.InputOutput{}).Where("id = ?", ioID).First(inputOutput).Error
+	if err != nil {
+		return nil, err
+	}
+
+	return inputOutput, nil
+}
+
+func (i *inputOutputRepository) Put(tx *gorm.DB, inputOutput *models.InputOutput) error {
+	err := tx.Save(inputOutput).Error
 	return err
 }
 

--- a/package/repository/mocks/mockgen.go
+++ b/package/repository/mocks/mockgen.go
@@ -441,8 +441,38 @@ func (mr *MockInputOutputRepositoryMockRecorder) DeleteAll(tx, taskID any) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAll", reflect.TypeOf((*MockInputOutputRepository)(nil).DeleteAll), tx, taskID)
 }
 
+// Get mocks base method.
+func (m *MockInputOutputRepository) Get(tx *gorm.DB, ioID int64) (*models.InputOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Get", tx, ioID)
+	ret0, _ := ret[0].(*models.InputOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Get indicates an expected call of Get.
+func (mr *MockInputOutputRepositoryMockRecorder) Get(tx, ioID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockInputOutputRepository)(nil).Get), tx, ioID)
+}
+
+// GetByTask mocks base method.
+func (m *MockInputOutputRepository) GetByTask(db *gorm.DB, taskID int64) ([]models.InputOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetByTask", db, taskID)
+	ret0, _ := ret[0].([]models.InputOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetByTask indicates an expected call of GetByTask.
+func (mr *MockInputOutputRepositoryMockRecorder) GetByTask(db, taskID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByTask", reflect.TypeOf((*MockInputOutputRepository)(nil).GetByTask), db, taskID)
+}
+
 // GetInputOutputID mocks base method.
-func (m *MockInputOutputRepository) GetInputOutputID(db *gorm.DB, taskID, order int64) (int64, error) {
+func (m *MockInputOutputRepository) GetInputOutputID(db *gorm.DB, taskID int64, order int) (int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetInputOutputID", db, taskID, order)
 	ret0, _ := ret[0].(int64)
@@ -454,6 +484,20 @@ func (m *MockInputOutputRepository) GetInputOutputID(db *gorm.DB, taskID, order 
 func (mr *MockInputOutputRepositoryMockRecorder) GetInputOutputID(db, taskID, order any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInputOutputID", reflect.TypeOf((*MockInputOutputRepository)(nil).GetInputOutputID), db, taskID, order)
+}
+
+// Put mocks base method.
+func (m *MockInputOutputRepository) Put(tx *gorm.DB, inputOutput *models.InputOutput) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Put", tx, inputOutput)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Put indicates an expected call of Put.
+func (mr *MockInputOutputRepositoryMockRecorder) Put(tx, inputOutput any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockInputOutputRepository)(nil).Put), tx, inputOutput)
 }
 
 // MockLanguageRepository is a mock of LanguageRepository interface.
@@ -506,21 +550,6 @@ func (m *MockLanguageRepository) Delete(tx *gorm.DB, languageID int64) error {
 func (mr *MockLanguageRepositoryMockRecorder) Delete(tx, languageID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockLanguageRepository)(nil).Delete), tx, languageID)
-}
-
-// Get mocks base method.
-func (m *MockLanguageRepository) Get(tx *gorm.DB, languageID int64) (*models.LanguageConfig, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Get", tx, languageID)
-	ret0, _ := ret[0].(*models.LanguageConfig)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Get indicates an expected call of Get.
-func (mr *MockLanguageRepositoryMockRecorder) Get(tx, languageID any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockLanguageRepository)(nil).Get), tx, languageID)
 }
 
 // GetAll mocks base method.

--- a/package/service/mocks/mockgen.go
+++ b/package/service/mocks/mockgen.go
@@ -285,6 +285,21 @@ func (mr *MockTaskServiceMockRecorder) GetByTitle(tx, title any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByTitle", reflect.TypeOf((*MockTaskService)(nil).GetByTitle), tx, title)
 }
 
+// GetLimits mocks base method.
+func (m *MockTaskService) GetLimits(tx *gorm.DB, currentUser schemas.User, taskID int64) ([]schemas.InputOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLimits", tx, currentUser, taskID)
+	ret0, _ := ret[0].([]schemas.InputOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetLimits indicates an expected call of GetLimits.
+func (mr *MockTaskServiceMockRecorder) GetLimits(tx, currentUser, taskID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLimits", reflect.TypeOf((*MockTaskService)(nil).GetLimits), tx, currentUser, taskID)
+}
+
 // ParseInputOutput mocks base method.
 func (m *MockTaskService) ParseInputOutput(archivePath string) (int, error) {
 	m.ctrl.T.Helper()
@@ -312,6 +327,20 @@ func (m *MockTaskService) ProcessAndUpload(tx *gorm.DB, currentUser schemas.User
 func (mr *MockTaskServiceMockRecorder) ProcessAndUpload(tx, currentUser, taskID, archivePath any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessAndUpload", reflect.TypeOf((*MockTaskService)(nil).ProcessAndUpload), tx, currentUser, taskID, archivePath)
+}
+
+// PutLimits mocks base method.
+func (m *MockTaskService) PutLimits(tx *gorm.DB, currentUser schemas.User, taskID int64, limits schemas.PutInputOutputRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PutLimits", tx, currentUser, taskID, limits)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PutLimits indicates an expected call of PutLimits.
+func (mr *MockTaskServiceMockRecorder) PutLimits(tx, currentUser, taskID, limits any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutLimits", reflect.TypeOf((*MockTaskService)(nil).PutLimits), tx, currentUser, taskID, limits)
 }
 
 // UnassignFromGroups mocks base method.

--- a/package/service/submission_service_test.go
+++ b/package/service/submission_service_test.go
@@ -176,8 +176,8 @@ func TestCreateSubmissionResult(t *testing.T) {
 					gomock.Any(),
 					gomock.Any(),
 					gomock.Any(),
-				).DoAndReturn(func(_ *gorm.DB, _, order int64) (int64, error) {
-					return order, nil
+				).DoAndReturn(func(_ *gorm.DB, _ int64, order int) (int64, error) {
+					return int64(order), nil
 				}).Times(1)
 				mTestRepo.EXPECT().Create(gomock.Any(), gomock.Any()).Return(gorm.ErrInvalidData).Times(1)
 			},
@@ -203,8 +203,8 @@ func TestCreateSubmissionResult(t *testing.T) {
 					gomock.Any(),
 					gomock.Any(),
 					gomock.Any(),
-				).DoAndReturn(func(_ *gorm.DB, _, order int64) (int64, error) {
-					return order, nil
+				).DoAndReturn(func(_ *gorm.DB, _ int64, order int) (int64, error) {
+					return int64(order), nil
 				}).Times(2)
 				mTestRepo.EXPECT().Create(gomock.Any(), gomock.Any()).Return(nil).Times(2)
 			},

--- a/package/service/task_service.go
+++ b/package/service/task_service.go
@@ -691,13 +691,13 @@ func (ts *taskService) GetLimits(tx *gorm.DB, currentUser schemas.User, taskID i
 		return nil, err
 	}
 
-	inputOuput, err := ts.inputOutputRepository.GetByTask(tx, taskID)
+	inputOutput, err := ts.inputOutputRepository.GetByTask(tx, taskID)
 	if err != nil {
 		return nil, err
 	}
 
-	result := make([]schemas.InputOutput, len(inputOuput))
-	for i, io := range inputOuput {
+	result := make([]schemas.InputOutput, len(inputOutput))
+	for i, io := range inputOutput {
 		result[i] = *InputOutputToSchema(&io)
 	}
 	return result, nil

--- a/package/service/task_service.go
+++ b/package/service/task_service.go
@@ -51,6 +51,8 @@ type TaskService interface {
 	Get(tx *gorm.DB, currentUser schemas.User, taskID int64) (*schemas.TaskDetailed, error)
 	// GetByTitle retrieves a task by its title.
 	GetByTitle(tx *gorm.DB, title string) (*schemas.Task, error)
+	// GetLimits retrieves limits associated with each input/output
+	GetLimits(tx *gorm.DB, currentUser schemas.User, taskID int64) ([]schemas.InputOutput, error)
 	// ParseInputOutput parses the input and output files from an archive.
 	ParseInputOutput(archivePath string) (int, error)
 	// ProcessAndUpload processes and uploads input and output files for a task.
@@ -59,6 +61,8 @@ type TaskService interface {
 	UnassignFromGroups(tx *gorm.DB, currentUser schemas.User, taskID int64, groupIDs []int64) error
 	// UnassignFromUsers unassigns a task from multiple users.
 	UnassignFromUsers(tx *gorm.DB, currentUser schemas.User, taskID int64, userID []int64) error
+	// PutLimits updates limits associated with each input/output.
+	PutLimits(tx *gorm.DB, currentUser schemas.User, taskID int64, limits schemas.PutInputOutputRequest) error
 }
 
 const defaultTaskSort = "created_at:desc"
@@ -678,6 +682,68 @@ func (ts *taskService) ProcessAndUpload(tx *gorm.DB, currentUser schemas.User, t
 	return nil
 }
 
+func (ts *taskService) GetLimits(tx *gorm.DB, currentUser schemas.User, taskID int64) ([]schemas.InputOutput, error) {
+	_, err := ts.taskRepository.Get(tx, taskID)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, myerrors.ErrNotFound
+		}
+		return nil, err
+	}
+
+	inputOuput, err := ts.inputOutputRepository.GetByTask(tx, taskID)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]schemas.InputOutput, len(inputOuput))
+	for i, io := range inputOuput {
+		result[i] = *InputOutputToSchema(&io)
+	}
+	return result, nil
+}
+
+func (ts *taskService) PutLimits(
+	tx *gorm.DB,
+	currentUser schemas.User,
+	taskID int64,
+	newLimits schemas.PutInputOutputRequest,
+) error {
+	task, err := ts.taskRepository.Get(tx, taskID)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return myerrors.ErrNotFound
+		}
+		return err
+	}
+
+	if task.CreatedBy != currentUser.ID && currentUser.Role != types.UserRoleAdmin {
+		return myerrors.ErrNotAuthorized
+	}
+
+	for _, io := range newLimits.Limits {
+		ioID, err := ts.inputOutputRepository.GetInputOutputID(tx, taskID, io.Order)
+		if err != nil {
+			return err
+		}
+
+		current, err := ts.inputOutputRepository.Get(tx, ioID)
+		if err != nil {
+			return err
+		}
+
+		current.MemoryLimit = io.MemoryLimit
+		current.TimeLimit = io.TimeLimit
+
+		err = ts.inputOutputRepository.Put(tx, current)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (ts *taskService) updateModel(currentModel *models.Task, updateInfo *schemas.EditTask) {
 	if updateInfo.Title != nil {
 		currentModel.Title = *updateInfo.Title
@@ -691,6 +757,16 @@ func TaskToSchema(model *models.Task) *schemas.Task {
 		CreatedBy: model.CreatedBy,
 		CreatedAt: model.CreatedAt,
 		UpdatedAt: model.UpdatedAt,
+	}
+}
+
+func InputOutputToSchema(model *models.InputOutput) *schemas.InputOutput {
+	return &schemas.InputOutput{
+		ID:          model.ID,
+		TaskID:      model.TaskID,
+		Order:       model.Order,
+		TimeLimit:   model.TimeLimit,
+		MemoryLimit: model.MemoryLimit,
 	}
 }
 


### PR DESCRIPTION
This pull request introduces new functionality for managing task limits, updates the API documentation, and refactors the `TaskRoute` implementation for consistency. The most significant changes include adding new endpoints for retrieving and updating task limits, updating the Swagger documentation, and renaming the `TaskRouteImpl` struct for better clarity.

### New functionality for managing task limits:
* Added `GetLimits` and `PutLimits` methods to the `TaskRoute` interface and implemented them in the `taskRoute` struct. These methods allow retrieving and updating task limits by task ID. (`internal/api/http/routes/task.go`) [[1]](diffhunk://#diff-74e705df6108a560bff37426ea9eb0e78fec04d6321701c48fc1f33e58be9be3R29-R38) [[2]](diffhunk://#diff-74e705df6108a560bff37426ea9eb0e78fec04d6321701c48fc1f33e58be9be3R761-R866)

### Updates to API documentation:
* Updated `docs/docs.go` to include new endpoints `/task/{id}/limits` for `GET` and `PUT` operations, providing detailed Swagger documentation for these endpoints. [[1]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4R1379-R1479) [[2]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4R2124-R2148)
* Updated `docs/swagger.yaml` to define the `PutInputOutput` and `PutInputOutputRequest` schemas and document the `/task/{id}/limits` endpoints. [[1]](diffhunk://#diff-85eaca9ed102c8ed649c4530f717cb96f291fb43486c47ff5075f5869cc00583R149-R164) [[2]](diffhunk://#diff-85eaca9ed102c8ed649c4530f717cb96f291fb43486c47ff5075f5869cc00583R1259-R1325)

### Codebase refactoring:
* Renamed `TaskRouteImpl` to `taskRoute` for consistency with naming conventions and updated all associated method signatures. (`internal/api/http/routes/task.go`) [[1]](diffhunk://#diff-74e705df6108a560bff37426ea9eb0e78fec04d6321701c48fc1f33e58be9be3L51-R53) [[2]](diffhunk://#diff-74e705df6108a560bff37426ea9eb0e78fec04d6321701c48fc1f33e58be9be3L82-R84) [[3]](diffhunk://#diff-74e705df6108a560bff37426ea9eb0e78fec04d6321701c48fc1f33e58be9be3L125-R127) [[4]](diffhunk://#diff-74e705df6108a560bff37426ea9eb0e78fec04d6321701c48fc1f33e58be9be3L171-R173) [[5]](diffhunk://#diff-74e705df6108a560bff37426ea9eb0e78fec04d6321701c48fc1f33e58be9be3L224-R226) [[6]](diffhunk://#diff-74e705df6108a560bff37426ea9eb0e78fec04d6321701c48fc1f33e58be9be3L286-R288) [[7]](diffhunk://#diff-74e705df6108a560bff37426ea9eb0e78fec04d6321701c48fc1f33e58be9be3L379-R381) [[8]](diffhunk://#diff-74e705df6108a560bff37426ea9eb0e78fec04d6321701c48fc1f33e58be9be3L471-R473) [[9]](diffhunk://#diff-74e705df6108a560bff37426ea9eb0e78fec04d6321701c48fc1f33e58be9be3L525-R527) [[10]](diffhunk://#diff-74e705df6108a560bff37426ea9eb0e78fec04d6321701c48fc1f33e58be9be3L587-R589) [[11]](diffhunk://#diff-74e705df6108a560bff37426ea9eb0e78fec04d6321701c48fc1f33e58be9be3L649-R651) [[12]](diffhunk://#diff-74e705df6108a560bff37426ea9eb0e78fec04d6321701c48fc1f33e58be9be3L711-R713)

### Linter configuration:
* Removed the `godot` linter from `.golangci.yaml` as it was deemed unnecessary. (`.golangci.yaml`)