### PR TITLE
feat: worker status endpoint

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -35,3 +35,14 @@ services:
       - "8888:8888"
     image: maxit/file-storage
     pull_policy: never
+  worker:
+    image: maxit/worker
+    pull_policy: never
+    depends_on:
+      - backend
+      - file-storage
+    environment:
+      - RABBITMQ_HOST=rabbitmq
+      - RABBITMQ_PORT=5672
+      - RABBITMQ_USER=guest
+      - RABBITMQ_PASSWORD=guest

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1892,6 +1892,44 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/worker/status": {
+            "get": {
+                "description": "Returns the current status of all worker nodes",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "worker"
+                ],
+                "summary": "Get worker status",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/APIResponse-WorkerStatus"
+                        }
+                    },
+                    "401": {
+                        "description": "Not authorized - requires teacher or admin role",
+                        "schema": {
+                            "$ref": "#/definitions/APIError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/APIError"
+                        }
+                    },
+                    "504": {
+                        "description": "Gateway timeout - worker status request timed out",
+                        "schema": {
+                            "$ref": "#/definitions/APIError"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -1977,6 +2015,17 @@ const docTemplate = `{
             "properties": {
                 "data": {
                     "$ref": "#/definitions/User"
+                },
+                "ok": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "APIResponse-WorkerStatus": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/WorkerStatus"
                 },
                 "ok": {
                     "type": "boolean"
@@ -2445,6 +2494,26 @@ const docTemplate = `{
                     "type": "string",
                     "maxLength": 30,
                     "minLength": 3
+                }
+            }
+        },
+        "WorkerStatus": {
+            "type": "object",
+            "properties": {
+                "busy_workers": {
+                    "type": "integer"
+                },
+                "status_time": {
+                    "type": "string"
+                },
+                "total_workers": {
+                    "type": "integer"
+                },
+                "worker_status": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -56,6 +56,13 @@ definitions:
       ok:
         type: boolean
     type: object
+  APIResponse-WorkerStatus:
+    properties:
+      data:
+        $ref: '#/definitions/WorkerStatus'
+      ok:
+        type: boolean
+    type: object
   APIResponse-array_Group:
     properties:
       data:
@@ -364,6 +371,19 @@ definitions:
     - password
     - surname
     - username
+    type: object
+  WorkerStatus:
+    properties:
+      busy_workers:
+        type: integer
+      status_time:
+        type: string
+      total_workers:
+        type: integer
+      worker_status:
+        additionalProperties:
+          type: string
+        type: object
     type: object
   errorStruct:
     properties:
@@ -1633,4 +1653,29 @@ paths:
       summary: Get user by email
       tags:
       - user
+  /worker/status:
+    get:
+      description: Returns the current status of all worker nodes
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/APIResponse-WorkerStatus'
+        "401":
+          description: Not authorized - requires teacher or admin role
+          schema:
+            $ref: '#/definitions/APIError'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/APIError'
+        "504":
+          description: Gateway timeout - worker status request timed out
+          schema:
+            $ref: '#/definitions/APIError'
+      summary: Get worker status
+      tags:
+      - worker
 swagger: "2.0"

--- a/internal/api/http/routes/worker.go
+++ b/internal/api/http/routes/worker.go
@@ -32,6 +32,10 @@ type workerRoute struct {
 // @Success      200 {object} httputils.APIResponse[schemas.WorkerStatus]
 // @Router       /worker/status [get]
 func (wr *workerRoute) GetStatus(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		httputils.ReturnError(w, http.StatusMethodNotAllowed, "Method not allowed")
+		return
+	}
 	currentUser := r.Context().Value(httputils.UserKey).(schemas.User)
 
 	status, err := wr.workserService.GetStatus(currentUser)

--- a/internal/api/http/routes/worker.go
+++ b/internal/api/http/routes/worker.go
@@ -1,0 +1,61 @@
+package routes
+
+import (
+	"net/http"
+
+	"errors"
+
+	"github.com/mini-maxit/backend/internal/api/http/httputils"
+	"github.com/mini-maxit/backend/package/domain/schemas"
+	myerrors "github.com/mini-maxit/backend/package/errors"
+	"github.com/mini-maxit/backend/package/service"
+)
+
+type WorkerRoute interface {
+	// GetStatus returns current status of workers
+	GetStatus(w http.ResponseWriter, r *http.Request)
+}
+
+type workerRoute struct {
+	workserService service.WorkerService
+}
+
+// GetStatus godoc
+//
+// @Tags         worker
+// @Summary      Get worker status
+// @Description  Returns the current status of all worker nodes
+// @Produce      json
+// @Failure      401 {object} httputils.APIError "Not authorized - requires teacher or admin role"
+// @Failure      504 {object} httputils.APIError "Gateway timeout - worker status request timed out"
+// @Failure      500 {object} httputils.APIError "Internal server error"
+// @Success      200 {object} httputils.APIResponse[schemas.WorkerStatus]
+// @Router       /worker/status [get]
+func (wr *workerRoute) GetStatus(w http.ResponseWriter, r *http.Request) {
+	currentUser := r.Context().Value(httputils.UserKey).(schemas.User)
+
+	status, err := wr.workserService.GetStatus(currentUser)
+	if err != nil {
+		if errors.Is(err, myerrors.ErrNotAuthorized) {
+			httputils.ReturnError(w, http.StatusUnauthorized, err.Error())
+			return
+		} else if errors.Is(err, myerrors.ErrTimeout) {
+			httputils.ReturnError(w, http.StatusGatewayTimeout, err.Error())
+			return
+		}
+		httputils.ReturnError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	httputils.ReturnSuccess(w, http.StatusOK, status)
+}
+
+func RegisterWorkerRoutes(mux *http.ServeMux, wr WorkerRoute) {
+	mux.HandleFunc("/status", wr.GetStatus)
+}
+
+func NewWorkerRoute(workserService service.WorkerService) WorkerRoute {
+	return &workerRoute{
+		workserService: workserService,
+	}
+}

--- a/internal/api/http/server/server.go
+++ b/internal/api/http/server/server.go
@@ -84,6 +84,10 @@ func NewServer(init *initialization.Initialization, log *zap.SugaredLogger) *Ser
 	sessionMux.HandleFunc("/validate", init.SessionRoute.ValidateSession)
 	sessionMux.HandleFunc("/invalidate", init.SessionRoute.InvalidateSession)
 
+	// Worker routes
+	workerMux := http.NewServeMux()
+	routes.RegisterWorkerRoutes(workerMux, init.WorkerRoute)
+
 	// Secure routes (require authentication)
 	secureMux := http.NewServeMux()
 	secureMux.Handle("/task/", http.StripPrefix("/task", taskMux))
@@ -91,6 +95,7 @@ func NewServer(init *initialization.Initialization, log *zap.SugaredLogger) *Ser
 	secureMux.Handle("/submission/", http.StripPrefix("/submission", subbmissionMux))
 	secureMux.Handle("/user/", http.StripPrefix("/user", userMux))
 	secureMux.Handle("/group/", http.StripPrefix("/group", groupMux))
+	secureMux.Handle("/worker/", http.StripPrefix("/worker", workerMux))
 
 	// API routes
 	apiMux := http.NewServeMux()

--- a/internal/api/queue/queue_listener.go
+++ b/internal/api/queue/queue_listener.go
@@ -281,7 +281,7 @@ func (ql *listener) processMessage(msg amqp.Delivery) {
 			return
 		}
 
-		err := ql.queueService.UpdateWorkerStatus(tx, statusResponse)
+		err := ql.queueService.UpdateWorkerStatus(statusResponse)
 		if err != nil {
 			ql.logger.Errorf("Failed to update worker status: %s", err.Error())
 			tx.Rollback()

--- a/internal/initialization/initialization.go
+++ b/internal/initialization/initialization.go
@@ -34,6 +34,7 @@ type Initialization struct {
 	SubmissionRoute routes.SubmissionRoutes
 	TaskRoute       routes.TaskRoute
 	UserRoute       routes.UserRoute
+	WorkerRoute     routes.WorkerRoute
 
 	QueueListener queue.Listener
 
@@ -223,6 +224,7 @@ func NewInitialization(cfg *config.Config) *Initialization {
 		taskService,
 		userService,
 	)
+	workerService := service.NewWorkerService(queueService)
 
 	// Routes
 	authRoute := routes.NewAuthRoute(userService, authService)
@@ -231,6 +233,7 @@ func NewInitialization(cfg *config.Config) *Initialization {
 	submissionRoute := routes.NewSubmissionRoutes(submissionService, cfg.FileStorageURL, queueService, taskService)
 	taskRoute := routes.NewTaskRoute(cfg.FileStorageURL, taskService)
 	userRoute := routes.NewUserRoute(userService)
+	workerRoute := routes.NewWorkerRoute(workerService)
 
 	// Queue listener
 	queueListener, err := queue.NewListener(
@@ -270,6 +273,7 @@ func NewInitialization(cfg *config.Config) *Initialization {
 		SubmissionRoute: submissionRoute,
 		TaskRoute:       taskRoute,
 		UserRoute:       userRoute,
+		WorkerRoute:     workerRoute,
 
 		QueueListener: queueListener,
 	}

--- a/package/domain/schemas/worker.go
+++ b/package/domain/schemas/worker.go
@@ -1,0 +1,10 @@
+package schemas
+
+import "time"
+
+type WorkerStatus struct {
+	BusyWorkers  int               `json:"busy_workers"`
+	TotalWorkers int               `json:"total_workers"`
+	WorkerStatus map[string]string `json:"worker_status"`
+	StatusTime   time.Time         `json:"status_time"`
+}

--- a/package/errors/errors.go
+++ b/package/errors/errors.go
@@ -130,3 +130,6 @@ var ErrInvalidArchive = errors.New(`archive contains a single file, expected a s
 
 // ErrExpectedStruct is returned when the input parameter should be a struct.
 var ErrExpectedStruct = errors.New("input param should be a struct")
+
+// ErrTimeout is returned when the operation times out.
+var ErrTimeout = errors.New("timeout waiting for response")

--- a/package/service/worker_service.go
+++ b/package/service/worker_service.go
@@ -1,0 +1,62 @@
+package service
+
+import (
+	"time"
+
+	"github.com/mini-maxit/backend/package/domain/schemas"
+	"github.com/mini-maxit/backend/package/domain/types"
+	"github.com/mini-maxit/backend/package/errors"
+	"github.com/mini-maxit/backend/package/utils"
+)
+
+type WorkerService interface {
+	GetStatus(currentUser schemas.User) (*schemas.WorkerStatus, error)
+}
+
+type workerService struct {
+	queueService QueueService
+}
+
+func (ws *workerService) GetStatus(currentUser schemas.User) (*schemas.WorkerStatus, error) {
+	if err := utils.ValidateRoleAccess(
+		currentUser.Role,
+		[]types.UserRole{types.UserRoleAdmin, types.UserRoleTeacher},
+	); err != nil {
+		return nil, errors.ErrNotAuthorized
+	}
+
+	err := ws.queueService.PublishWorkerStatus()
+	if err != nil {
+		return nil, err
+	}
+	// Set a timeout for waiting
+	timeout := time.After(10 * time.Second)
+	statusUpdated := make(chan bool, 1)
+	var result schemas.WorkerStatus
+
+	go func() {
+		ws.queueService.StatusMux().Lock()
+		defer ws.queueService.StatusMux().Unlock()
+
+		// Wait for the condition to be signaled
+		ws.queueService.StatusCond().Wait()
+
+		// When signaled, capture the result while holding the lock
+		result = ws.queueService.LastWorkerStatus()
+		statusUpdated <- true
+	}()
+
+	// Wait for either the status update or timeout
+	select {
+	case <-statusUpdated:
+		return &result, nil
+	case <-timeout:
+		return nil, errors.ErrTimeout
+	}
+}
+
+func NewWorkerService(queueService QueueService) WorkerService {
+	return &workerService{
+		queueService: queueService,
+	}
+}


### PR DESCRIPTION
This pull request introduces a new feature to manage and monitor worker nodes in the system. It includes changes to the API, service layer, and supporting configurations. The key additions are a new `/worker/status` endpoint, a `WorkerService` for handling worker-related operations, and updates to the queue service to track worker statuses. Below is a breakdown of the most important changes:

### API Enhancements
* Added a new `/worker/status` endpoint to the API, allowing authorized users (admin or teacher roles) to fetch the current status of all worker nodes. This endpoint is documented in both `docs/docs.go` and `docs/swagger.yaml`. [[1]](diffhunk://#diff-5b86a7d1c0ef2128711883b00753503576056013dcbb5af05de567033777aeb4R1794-R1831) [[2]](diffhunk://#diff-85eaca9ed102c8ed649c4530f717cb96f291fb43486c47ff5075f5869cc00583R1573-R1597)
* Created a new `WorkerRoute` in `internal/api/http/routes/worker.go` to handle the `/worker/status` endpoint. The route integrates with the `WorkerService` to fetch and return worker statuses.

### Service Layer Updates
* Introduced a `WorkerService` in `package/service/worker_service.go` to manage worker-related operations, including publishing status requests and waiting for updates via a condition variable.
* Enhanced the `QueueService` in `package/service/queue_service.go` to include synchronization primitives (`sync.Mutex` and `sync.Cond`) for managing worker status updates and broadcasting changes. [[1]](diffhunk://#diff-42d99749ac09d5dc6006f5d00791c34641a17487fe5257c18b1e424b43c279dfL30-R34) [[2]](diffhunk://#diff-42d99749ac09d5dc6006f5d00791c34641a17487fe5257c18b1e424b43c279dfL176-R211)

### Schema and Error Handling
* Added a new `WorkerStatus` struct in `package/domain/schemas/worker.go` to represent the status of worker nodes, including busy workers, total workers, and individual worker statuses.
* Added a new `ErrTimeout` in `package/errors/errors.go` to handle timeout scenarios when waiting for worker status updates.

### Configuration and Initialization
* Updated `docker-compose.yaml` to include a new `worker` service, which depends on the backend and file storage services.
* Modified `internal/initialization/initialization.go` to initialize the `WorkerService` and register the `WorkerRoute`. [[1]](diffhunk://#diff-a0c223a79819da639451146cc4c5353ceaf4c392457b05338e0b335f44af1f46R37) [[2]](diffhunk://#diff-a0c223a79819da639451146cc4c5353ceaf4c392457b05338e0b335f44af1f46R227)