### PR TITLE
chore: update Docker workflow for improved tagging and caching

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -1,17 +1,23 @@
 name: Build and Push Docker Image
 
 on:
-  push:
+  workflow_run:
+    workflows: ["Go Build and Test"]
+    types:
+      - completed
     branches:
       - '**'
 
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -24,7 +30,7 @@ jobs:
 
       - name: Extract branch name
         shell: bash
-        run: echo "BRANCH_NAME=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+        run: echo "BRANCH_NAME=${{ github.event.workflow_run.head_branch }}" >> $GITHUB_ENV
 
       - name: Set Docker tag
         run: |


### PR DESCRIPTION
This pull request modifies the `.github/workflows/docker-image.yaml` file to improve the automation of Docker image builds by triggering the workflow based on the completion of another workflow and ensuring the correct branch and commit are used. The most important changes are grouped below:

### Workflow trigger and conditions:
* Changed the workflow trigger from `push` to `workflow_run`, specifying that it should run after the "Go Build and Test" workflow completes successfully. Added a condition to ensure the workflow only proceeds if the previous workflow's conclusion is `success`.

### Branch and commit reference updates:
* Updated the `Checkout code` step to check out the specific commit (`head_sha`) from the triggering workflow run.
* Modified the `Extract branch name` step to use the `head_branch` from the triggering workflow run instead of deriving it from `GITHUB_REF`.