### PR TITLE
Matios102 patch 1

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -44,3 +44,5 @@ jobs:
           tags: ${{ vars.DOCKER_REPO }}/maxit-backend:${{ env.DOCKER_TAG }}
           cache-from: type=registry,ref=${{ vars.DOCKER_REPO }}/maxit-backend:buildcache
           cache-to: type=registry,ref=${{ vars.DOCKER_REPO }}/maxit-backend:buildcache,mode=max
+          platforms: linux/amd64,linux/arm64/v8
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/mini-maxit/backend)
+
 # Development
 
 ## Run


### PR DESCRIPTION
This pull request adds support for multi-platform Docker builds in the GitHub Actions workflow for the `maxit-backend` project.

Key change:

* [`.github/workflows/docker-image.yaml`](diffhunk://#diff-a9b4f1a51dd81dfaef1e9d563dfe6045ab8089a05200453d6e0b2d66201f419fR47-R48): Added the `platforms` field to specify support for both `linux/amd64` and `linux/arm64/v8` architectures in the Docker build process.