### PR TITLE
fix: corrected volume name

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -55,7 +55,7 @@ services:
       - RABBITMQ_USER=guest
       - RABBITMQ_PASSWORD=guest
       - DOCKER_HOST=unix:///var/run/docker.sock
-      - JOBS_DATA_VOLUME=worker_jobs-data
+      - JOBS_DATA_VOLUME=jobs-data
   frontend:
     image: maxit/frontend
     pull_policy: never
@@ -75,3 +75,4 @@ services:
 volumes:
   file-storage-media:
   jobs-data:
+    name: jobs-data


### PR DESCRIPTION
Due to a volume name mismatch, the executor container did not contain the solution package but instead had an empty folder, causing the execution to fail. This PR fixes the naming of the worker jobs-data volume name.